### PR TITLE
Apply Google Music Mac custom CSS by default

### DIFF
--- a/GoogleMusic/AppDelegate.h
+++ b/GoogleMusic/AppDelegate.h
@@ -28,6 +28,7 @@
 - (void) notifySong:(NSString *)title withArtist:(NSString *)artist album:(NSString *)album art:(NSString *)art;
 
 - (void) evaluateJavaScriptFile:(NSString *)name;
+- (void) applyCSSFile:(NSString *)name;
 + (NSString *) webScriptNameForSelector:(SEL)sel;
 + (BOOL) isSelectorExcludedFromWebScript:(SEL)sel;
 

--- a/GoogleMusic/AppDelegate.m
+++ b/GoogleMusic/AppDelegate.m
@@ -24,6 +24,11 @@
  */
 - (void)applicationDidFinishLaunching:(NSNotification *)aNotification
 {
+    [window setBackgroundColor:[NSColor colorWithCalibratedRed:0.88f
+                                                         green:0.88f
+                                                          blue:0.88f
+                                                         alpha:1.0f]];
+    
 	// Add an event tap to intercept the system defined media key events
     eventTap = CGEventTapCreate(kCGSessionEventTap,
                                 kCGHeadInsertEventTap,
@@ -162,6 +167,8 @@ static CGEventRef event_tap_callback(CGEventTapProxy proxy,
 {
     [self evaluateJavaScriptFile:@"main"];
     [self evaluateJavaScriptFile:@"keyboard"];
+    [self evaluateJavaScriptFile:@"styles"];
+    [self applyCSSFile:@"cocoa"];
     [[sender windowScriptObject] setValue:self forKey:@"googleMusicApp"];
 }
 
@@ -190,6 +197,19 @@ static CGEventRef event_tap_callback(CGEventTapProxy proxy,
     NSString *js = [NSString stringWithContentsOfFile:path encoding:NSUTF8StringEncoding error:NULL];
     
     [webView stringByEvaluatingJavaScriptFromString:js];
+}
+
+- (void) applyCSSFile:(NSString *)name
+{
+    NSString *path = [[NSBundle mainBundle] pathForResource:name ofType:@"css"];
+    NSString *css = [NSString stringWithContentsOfFile:path encoding:NSUTF8StringEncoding error:NULL];
+    css = [css stringByReplacingOccurrencesOfString:@"\n" withString:@"\\n"];
+    css = [css stringByReplacingOccurrencesOfString:@"\"" withString:@"\\\""];
+    
+    NSString *bootstrap = @"Styles.applyStyle(\"%@\", \"%@\");";
+    NSString *final = [NSString stringWithFormat:bootstrap, name, css];
+    
+    [webView stringByEvaluatingJavaScriptFromString:final];
 }
 
 + (NSString *) webScriptNameForSelector:(SEL)sel

--- a/GoogleMusic/cocoa.css
+++ b/GoogleMusic/cocoa.css
@@ -1,0 +1,290 @@
+#main, .song-row td {
+    background-color: white;
+}
+
+.g-content {
+    margin: 0;
+}
+
+.song-table {
+    padding: 0;
+}
+
+.song-table .header-row th {
+    background: linear-gradient(0deg, #f1f1f1, #d8d8d8);
+    border-bottom: 1px solid #CCCCCC;
+    height: 26px;
+    text-transform: none;
+    border-right: 1px solid #BABABA;
+    border-left: 1px solid #EAEAEA;
+}
+
+.song-row:nth-child(odd) td {
+    background-color: #F4F7FB !important;
+}
+
+.song-row img {
+    height: 26px !important;
+    width: 26px !important;
+    visibility: hidden;
+}
+
+.song-row .song-indicator {
+    width: 32px !important;
+    height: 26px !important;
+}
+
+.song-row .song-indicator[data-playback-status="loading"] {
+    background-position: -4px -7px;
+}
+
+.song-row .song-indicator[data-playback-status="paused"] {
+    background-position: -404px -2193px;
+}
+
+.song-row td {
+    height: 26px;
+    min-height: 26px;
+    max-height: 26px;
+    line-height: 26px;
+    border: none;
+    font-size: 12px;
+    color: black;
+    border-right: 1px solid #EAEAEA;
+    cursor: default;
+    background-color: white !important
+}
+
+.song-row.selected-song-row td {
+    color: white !important;
+    background-color: #6396E1 !important;
+    background-color: #ff8200 !important;
+}
+
+.song-row.selected-song-row .song-indicator {
+    -webkit-filter: brightness(0%) invert(100%);
+    background-color: transparent;
+}
+
+.song-row .hover-button[data-id=play] {
+    height: 26px;
+    width: 26px;
+}
+
+.song-row .hover-button {
+    margin-top: 1px;
+}
+
+.song-row .explicit {
+    margin-top: 8px;
+}
+
+.song-row .rating-container.thumbs [data-rating] {
+    margin-top: 0px;
+}
+
+.song-row [data-col="rating"][data-rating] {
+    background-position: -1934px -1417px;
+}
+
+.song-row .hover-button[data-id=play] {
+    height: 26px !important;
+    width: 26px !important;
+    background-position: -1377px -1367px;
+    display: none;
+}
+
+.song-row .hover-button[data-id="menu"], .song-row .hover-button[data-id="menu"]:hover {
+    margin: 1px 0 0 0;
+    border: none;
+    border-radius: 0;
+}
+
+.song-row.selected-song-row .hover-button[data-id="menu"] {
+    background-color: transparent !important;
+    -webkit-filter: brightness(20%) invert(100%);
+}
+
+.music-banner {
+    display: none;
+}
+
+#nav {
+    top: 0;
+    background-color: #DBDFE7;
+    border-right: 1px solid #999999;
+    border-top: 1px solid #CCCCCC;
+    width: auto;
+    margin: 0;
+}
+
+#nav_collections .nav-item-container, .nav-item-container {
+    font-size: 13px !important;
+    font-weight: 400 !important;
+    color: #333 !important;
+    height: 26px !important;
+    line-height: 26px !important;
+    cursor: default !important;
+}
+
+#nav_collections .nav-item-container.selected, .nav-item-container.selected, .nav-item-container.selected:focus, .nav-item-container.selected:hover {
+    background: linear-gradient(0deg, #6482a4, #96b5d8) !important;
+    background: linear-gradient(0deg, #ff7d00, #ff9d20) !important;
+    color: white !important;
+    font-weight: 500;
+}
+
+.nav-item-container:hover {
+    background: none;
+}
+
+.nav-section-header {
+    padding-left: 10px;
+    font-weight: bold;
+    color: #66717F;
+    text-shadow: 0px 1px 0px #FCFAFF;
+}
+
+.nav-section-divider {
+    display: none;
+}
+
+.nav-item-container:hover .playlistDropDown, .nav-item-container:hover .playlistDropDown:hover, .nav-item-container.selected .playlistDropDown, .nav-item-container.selected .playlistDropDown:hover {
+    background-color: transparent !important;
+    margin-top: 1px !important;
+}
+
+.nav-item-container.selected .playlistDropDown, .nav-item-container.selected .playlistDropDown:hover {
+    -webkit-filter: brightness(20%) invert(100%);
+}
+
+.nav-bar .header-tab-title.selected {
+    border: 1px solid #aaa;
+    border-radius: 20px;
+    background-image: linear-gradient(0deg, #f8f8f8, #e0e0e0);
+    box-shadow: inset 0px 1px 1px #bbb;
+}
+
+.nav-bar .header-tab-title {
+    height: 28px;
+    line-height: 29px;
+    margin-top: 8px;
+    cursor: default;
+}
+
+.nav-bar .header-tab-title:hover {
+    background-color: transparent;
+}
+
+.nav-bar #breadcrumbs {
+    background: none;
+}
+
+.nav-bar {
+    background-image: linear-gradient(0deg, #f8f8f8, #ffffff);
+}
+
+
+.fade-out:after {
+    background: none !important;
+}
+
+#player, .player-middle {
+    background: linear-gradient(0deg, #b5b5b5, #efefef);
+    border-top: 1px solid #a0a0a0;
+}
+
+.player-middle {
+    padding: 3px 0 0 0;
+    margin: 0;
+}
+
+#player .flat-button, #player .flat-button:hover, #player .flat-button:active {
+    background-color: transparent !important;
+}
+
+.now-playing-menu-wrapper {
+    background: none;
+}
+
+#player [data-id="now-playing-menu"] {
+    border: none;
+}
+
+#player .rating-container.thumbs li.selected:hover, #player .rating-container.thumbs li:hover {
+    background-color: transparent;
+}
+
+#volume:hover, #volume.simulated-hover {
+    background: none !important;
+}
+
+#volume #vslider, #volume #volume_low, #volume #volume_high {
+    opacity: 1 !important;
+}
+
+.gb_oa {
+    /*-webkit-filter: grayscale(100%) brightness(50%) invert(0%);*/
+}
+
+.gb_jb {
+    background: linear-gradient(0deg, #b5b5b5, #d5d5d5 50%, #e5e5e5);
+    border-bottom: 1px solid #606060;
+    height: 59px;
+}
+
+.gbqfqw { 
+    border-radius: 15px;
+    border-color: #808080;
+    box-shadow: inset 0px 2px 3px #aaa;
+    border-right-width: 1px
+}
+
+#gbqfb {
+    width: 24px;
+    min-width: 24px;
+    margin-left: -30px;
+    position: absolute;
+    height: 24px;
+    margin-top: 4px;
+    background: none;
+}
+
+.gbqfi.gb_g {
+    width: 24px;
+    height: 24px;
+    background-position: -470px -210px;
+    -webkit-filter: invert(66%);
+}
+
+#gbqfb:active {
+    background: none;
+    box-shadow: none;
+    -webkit-filter: brightness(0%);
+}
+
+#gbqfq {
+    margin-top: 5px !important;
+    padding-left: 2px !important;
+    font-size: 14px !important;
+}
+
+div.simple-dialog-bg {
+    opacity: 0.01 !important;
+    background-color: transparent;
+}
+
+.simple-dialog {
+    top: 60px !important;
+    background-color: rgba(240,240,240,0.96);
+    border-radius: 0 0 5px 5px;
+    border-top-width: 0;
+}
+
+.simple-dialog-title, .simple-dialog-content {
+    background-color: transparent;
+}
+
+.butter-bar-container {
+    top: 0;
+}

--- a/GoogleMusic/styles.js
+++ b/GoogleMusic/styles.js
@@ -1,0 +1,26 @@
+if (typeof window.Styles === 'undefined') {
+    window.Styles = {
+        appliedStyles: {},
+        
+        applyStyle: function(key, css) {
+            if (Styles.appliedStyles[key]) {
+                Styles.appliedStyles[key].disabled = false;
+            }
+            else {
+                var style = document.createElement('style');
+                style.type = 'text/css';
+                style.innerHTML = css;
+                style.id = 'style-' + key;
+                
+                document.getElementsByTagName('head')[0].appendChild(style);
+                Styles.appliedStyles[key] = style;
+            }
+        },
+        
+        disableStyle: function(key) {
+            if (Styles.appliedStyles[key]) {
+                Styles.appliedStyles[key].disabled = true;
+            }
+        }
+    };
+}


### PR DESCRIPTION
Some custom written CSS overrides and styles to make the Google Music
site look more like a native Mac OS X music player.
