### PR TITLE
Add back the play log while keeping the forward and backward button

### DIFF
--- a/google-music-mac/js/navigation.js
+++ b/google-music-mac/js/navigation.js
@@ -16,13 +16,11 @@ if (typeof window.GMNavigation === 'undefined') {
     
     var logoContainer = document.querySelector('#oneGoogleWrapper > div:first-child > div:first-child > div:nth-child(2) > div:first-child');
     
-    // Remove the children of the container.
-    while (logoContainer.firstChild) {
-        logoContainer.removeChild(logoContainer.firstChild);
-    }
-    
     // Remove the width constraints of the parent element.
     logoContainer.parentNode.style.cssText = '';
+    
+    // Make room for the forward and backward button.
+    logoContainer.parentNode.style.width = "310px"
     
     // Change the styles of the sibling elements of the logo.
     document.querySelector('#oneGoogleWrapper > div:first-child > div:first-child > div:nth-child(1)').style.webkitFlexGrow = 0;


### PR DESCRIPTION
I want to create this pull request because the removing the the google log doesn't make UI feel right. e.g. the search bar is not too close to the left. So I want to keep the logo while keeping the button. Though now it is still not perfect, I think it looks better than without the logo.
