### PR TITLE
Fix for archiving when there’s a space in the build path

### DIFF
--- a/google-music-mac.xcodeproj/project.pbxproj
+++ b/google-music-mac.xcodeproj/project.pbxproj
@@ -385,7 +385,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "cd ${BUILT_PRODUCTS_DIR}\nrm \"${PRODUCT_NAME}.zip\"\nzip -u -r -1 \"${PRODUCT_NAME}.zip\" \"${PRODUCT_NAME}.app/\"";
+			shellScript = "cd \"${BUILT_PRODUCTS_DIR}\"\nrm \"${PRODUCT_NAME}.zip\" 2> /dev/null\nzip -u -r -1 \"${PRODUCT_NAME}.zip\" \"${PRODUCT_NAME}.app/\"";
 		};
 /* End PBXShellScriptBuildPhase section */
 


### PR DESCRIPTION
Fixes 2 issues when building. First, I was unable to archive the project at all due to having a space in my project path. Second, I kept getting a warning about not being able to delete a .zip file in the project (simply because that file didn't exist).
