### PR TITLE
Change album title to white on dark theme

### DIFF
--- a/google-music-mac/css/dark.css
+++ b/google-music-mac/css/dark.css
@@ -53,7 +53,7 @@ a, .simple-dialog a {
 }
 
 #headerBar .tab-text.has-parent {
-    color: #000;
+    color: #fff;
 }
 
 .card {


### PR DESCRIPTION
Currently is black on black so impossible to read as raised here: https://github.com/kbhomes/google-music-mac/issues/100
