### PR TITLE
Change window level of preferences pane to be always on top

### DIFF
--- a/google-music-mac/Preferences/PreferencesWindowController.m
+++ b/google-music-mac/Preferences/PreferencesWindowController.m
@@ -43,6 +43,7 @@
     // Activate the app in case it is hidden.
     [NSApp activateIgnoringOtherApps:YES];
     [super showWindow:sender];
+    [self.window setLevel:NSPopUpMenuWindowLevel];
 }
 
 @end


### PR DESCRIPTION
Fixed this one by adding `[self.window setLevel:NSPopUpMenuWindowLevel];` to the preferences `showWindow` method.
