### PR TITLE
No longer depends on high performance GPU.

### DIFF
--- a/google-music-mac/info.plist
+++ b/google-music-mac/info.plist
@@ -34,6 +34,8 @@
 	<string>MainMenu</string>
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
+	<key>NSSupportsAutomaticGraphicsSwitching</key>
+	<true/>
 	<key>OSAScriptingDefinition</key>
 	<string>google-music-mac.sdef</string>
 </dict>


### PR DESCRIPTION
I set a Boolean to true in info.plist that lets openGL run on the integrated GPU. Referenced [this](https://developer.apple.com/library/mac/qa/qa1734/_index.html) page. 
