### PR TITLE
Change of the track number color for the dark themes

### DIFF
--- a/radiant-player-mac/css/dark-flat.css
+++ b/radiant-player-mac/css/dark-flat.css
@@ -162,7 +162,7 @@ a, .simple-dialog a {
 
 .song-table [data-col="index"] .content, 
 .song-table [data-col="track"] .content {
-    color: inherit;
+    color: white;
 }
 
 .song-row.currently-playing td[data-col="track"] span,

--- a/radiant-player-mac/css/dark.css
+++ b/radiant-player-mac/css/dark.css
@@ -169,7 +169,7 @@ a, .simple-dialog a {
 
 .song-table [data-col="index"] .content, 
 .song-table [data-col="track"] .content {
-    color: inherit;
+    color: white;
 }
 
 .song-row.currently-playing td[data-col="track"] span,


### PR DESCRIPTION
First, I would tell you thanks for your work, it's a pleasure of using Google Play with Radiant and the keyboard integration :)

This PR fixes the problem in the dark themes and the track number that was not visible while the row was not selected.
