### PR TITLE
Fix scripting bridge include bug

### DIFF
--- a/radiant-player-mac/AppleScript/radiant-player-mac.sdef
+++ b/radiant-player-mac/AppleScript/radiant-player-mac.sdef
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE dictionary SYSTEM "file://localhost/System/Library/DTDs/sdef.dtd">
-<dictionary title="Radiant Player Terminology">
+<dictionary title="Radiant Player Terminology" xmlns:xi="http://www.w3.org/2003/XInclude">
 	<xi:include href="file:///System/Library/ScriptingDefinitions/CocoaStandard.sdef" xpointer="xpointer(/dictionary/suite)"/>
     
     <suite name="Radiant Player Suite" code="GMMs" description="The suite specific to Radiant Player for Google Play Music">


### PR DESCRIPTION
This fixed the bug described in #186 for me.
I tested it on 10.10.3 and I hope it doesn't break something else.