### PR TITLE
Lastfm scrobbling fix for El Capitan users

### DIFF
--- a/radiant-player-mac/info.plist
+++ b/radiant-player-mac/info.plist
@@ -21,13 +21,24 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.4.0</string>
+	<string>1.4.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.music</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>${MACOSX_DEPLOYMENT_TARGET}</string>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSExceptionDomains</key>
+		<dict>
+			<key>ws.audioscrobbler.com</key>
+			<dict>
+				<key>NSExceptionRequiresForwardSecrecy</key>
+				<false/>
+			</dict>
+		</dict>
+	</dict>
 	<key>NSAppleScriptEnabled</key>
 	<true/>
 	<key>NSMainNibFile</key>


### PR DESCRIPTION
The upgrade to El Capitan appears to have broken scrobbling (reported in #368). This looks to be down to down to the addition of ATS as detailed here: https://developer.apple.com/library/prerelease/mac/releasenotes/MacOSX/WhatsNewInOSX/Articles/MacOSX10_11.html

A quick check of the api in Chrome shows the following error:

```
This site uses a weak security configuration (SHA-1 signatures), so your connection may not be private
```

This change disables ATS, allowing connection to the last.fm api. I'm logging a separate ticket with last.fm to (hopefully) update the configuration at their end.