### PR TITLE
More last.fm ATS exceptions to stop error when opening last.fm recent tracks

### DIFF
--- a/radiant-player-mac/LastFm/LastFmService.m
+++ b/radiant-player-mac/LastFm/LastFmService.m
@@ -151,7 +151,7 @@
 - (void)openRecentTracksPage:(id)sender
 {
     NSString *username = [[[LastFm sharedInstance] username] stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
-    NSString *page = [NSString stringWithFormat:@"http://www.last.fm/user/%@", username];
+    NSString *page = [NSString stringWithFormat:@"https://www.last.fm/user/%@", username];
     NSURL *url = [NSURL URLWithString:page];
     
     [[NSWorkspace sharedWorkspace] openURL:url];

--- a/radiant-player-mac/info.plist
+++ b/radiant-player-mac/info.plist
@@ -20,12 +20,12 @@
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
-	<key>CFBundleVersion</key>
-	<string>1.5.0</string>
 	<key>CFBundleShortVersionString</key>
 	<string>1.5.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>1.5.0</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.music</string>
 	<key>LSMinimumSystemVersion</key>
@@ -36,6 +36,24 @@
 		<dict>
 			<key>ws.audioscrobbler.com</key>
 			<dict>
+				<key>NSExceptionRequiresForwardSecrecy</key>
+				<false/>
+			</dict>
+			<key>last.fm</key>
+			<dict>
+				<key>NSExceptionAllowsInsecureHTTPLoads</key>
+				<true/>
+				<key>NSIncludesSubdomains</key>
+				<true/>
+				<key>NSExceptionRequiresForwardSecrecy</key>
+				<false/>
+			</dict>
+			<key>lst.fm</key>
+			<dict>
+				<key>NSExceptionAllowsInsecureHTTPLoads</key>
+				<true/>
+				<key>NSIncludesSubdomains</key>
+				<true/>
 				<key>NSExceptionRequiresForwardSecrecy</key>
 				<false/>
 			</dict>
@@ -51,10 +69,10 @@
 	<true/>
 	<key>OSAScriptingDefinition</key>
 	<string>radiant-player-mac.sdef</string>
-	<key>SUPublicDSAKeyFile</key>
-	<string>radiant-player-mac-dsa-pub.pem</string>
 	<key>SUFeedURL</key>
 	<string>https://radiant-player.github.io/radiant-player-mac/appcast/appcast.xml</string>
+	<key>SUPublicDSAKeyFile</key>
+	<string>radiant-player-mac-dsa-pub.pem</string>
 	<key>SUScheduledCheckInterval</key>
 	<integer>3600</integer>
 </dict>


### PR DESCRIPTION
Reproducible by opening the app on El Capitan, and clicking the last.fm logo top right (while logged into last.fm).

The API seems to be returning a mix of http and https urls, over a couple of different domains.  Similar to https://github.com/radiant-player/radiant-player-mac/pull/378, this is causing radiant to drop the connection in el capitan, which in turns causes an unhandled exception.

This PR:
- Adds exceptions for both the main site and their CDN
- Allows insecure (http) loads for both
- Disables the forward secrecy requirement (because even if they do fix the URLs, most likely their cert chain will still be insecure)
- Applies the above to all related subdomains

I've also updated the profile link to use https - which currently just redirects to http, but at least it's there for once last.fm get their shit together :-)

Sorry for the random reordering of the info.plist keys, I think xcode did that in the background :ok_hand: 
