### PR TITLE
Remove broken observer

### DIFF
--- a/radiant-player-mac/js/main.js
+++ b/radiant-player-mac/js/main.js
@@ -245,18 +245,6 @@ if (typeof window.MusicAPI === 'undefined') {
                 if (name == 'now-playing-info-wrapper')  {
                     
                     // Fire the rating observer if the thumbs exist (no harm if already observing)
-                    var ratingEls = document.querySelectorAll('.player-rating-container [data-rating]');
-                    for (var j = 0; j < ratingEls.length; j++) {
-                        var ratingEl = ratingEls[j];
-                        
-                        if (ratingEl.observe.icon != 'iconChanged_') {
-                            ratingEl.observe.icon = 'iconChanged_';
-                            ratingEl.iconChanged_ = function(oldIcon) {
-                                this.iconChanged(oldIcon);
-                                GoogleMusicApp.ratingChanged(MusicAPI.Rating.getRating());
-                            };
-                        }
-                    }
                     GoogleMusicApp.ratingChanged(MusicAPI.Rating.getRating());
                     
                     var now = new Date();


### PR DESCRIPTION
This PR removes part of the rating button observers - they appear to be broken with the current code from Google.  I've just removed them here as I'm not sure if they're necessary anymore and if so I'm not sure how to reimplement.  I will say though that when combined with #389, it appears to restore LastFM scrobbling and growl notifications.