### PR TITLE
core-drawer-panel -> paper-drawer-panel

### DIFF
--- a/radiant-player-mac/css/navigation.css
+++ b/radiant-player-mac/css/navigation.css
@@ -28,12 +28,12 @@
 
 /* When the navigation drawer is open, or Radiant Player is full screen */
 body.full-screen #rp-padding-left,
-core-drawer-panel:not([narrow]) #rp-padding-left {
+paper-drawer-panel:not([narrow]) #rp-padding-left {
     min-width: 0px;
 }
 
 body.full-screen #sliding_action_bar_container.material,
-core-drawer-panel:not([narrow]) #sliding_action_bar_container.material {
+paper-drawer-panel:not([narrow]) #sliding_action_bar_container.material {
     padding-left: 16px;
 }
 


### PR DESCRIPTION
[core-drawer-panel](https://github.com/Polymer/core-drawer-panel) has been deprecated in favor of [paper-drawer-panel](https://github.com/PolymerElements/paper-drawer-panel)

This fixes a minor annoyance with the top nav when the left menu was open.

Before:

<img width="615" alt="screenshot 2015-11-22 12 43 28" src="https://cloud.githubusercontent.com/assets/206295/11324990/23449e32-9118-11e5-9cc0-a0abd97907d1.png">

After:

<img width="638" alt="screenshot 2015-11-22 12 43 52" src="https://cloud.githubusercontent.com/assets/206295/11324992/2d561bc6-9118-11e5-9d2d-2da08248c9af.png">
