### PR TITLE
DarkCyan theme, plus some Spotify theme fixes

### DIFF
--- a/radiant-player-mac.xcodeproj/project.pbxproj
+++ b/radiant-player-mac.xcodeproj/project.pbxproj
@@ -25,7 +25,7 @@
 		D3091F6918C40FBD007C8DCD /* SwipeAnimation.m in Sources */ = {isa = PBXBuildFile; fileRef = D3091F6818C40FBD007C8DCD /* SwipeAnimation.m */; };
 		D30CA00519383160007B05B2 /* NSApplication+ScriptingProperties.m in Sources */ = {isa = PBXBuildFile; fileRef = D30CA00419383160007B05B2 /* NSApplication+ScriptingProperties.m */; };
 		D30CA0081938722F007B05B2 /* NSImage+ScriptingDescriptor.m in Sources */ = {isa = PBXBuildFile; fileRef = D30CA0071938722F007B05B2 /* NSImage+ScriptingDescriptor.m */; };
-		D30F57891BDB7B2200929904 /* Sparkle.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D30F57881BDB7B2200929904 /* Sparkle.framework */; settings = {ASSET_TAGS = (); }; };
+		D30F57891BDB7B2200929904 /* Sparkle.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D30F57881BDB7B2200929904 /* Sparkle.framework */; };
 		D30F578B1BDB7BD300929904 /* Sparkle.framework in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = D30F57881BDB7B2200929904 /* Sparkle.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		D318341718CFBC7400E8F9B1 /* AppearancePreferencesViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = D318341618CFBC7400E8F9B1 /* AppearancePreferencesViewController.m */; };
 		D318341B18CFC7C500E8F9B1 /* ApplicationStyle.m in Sources */ = {isa = PBXBuildFile; fileRef = D318341A18CFC7C500E8F9B1 /* ApplicationStyle.m */; };
@@ -54,7 +54,7 @@
 		D370E8E018E21ABC007B5450 /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D370E8DF18E21ABC007B5450 /* QuartzCore.framework */; };
 		D370E8E318E2BFE1007B5450 /* ExpandHoverView.m in Sources */ = {isa = PBXBuildFile; fileRef = D370E8E218E2BFE1007B5450 /* ExpandHoverView.m */; };
 		D377DB5B1B0A6F5900026312 /* JSURLProtocol.m in Sources */ = {isa = PBXBuildFile; fileRef = D377DB5A1B0A6F5900026312 /* JSURLProtocol.m */; };
-		D37A5FCB1BDBEA6A0027FBD4 /* radiant-player-mac-dsa-pub.pem in Resources */ = {isa = PBXBuildFile; fileRef = D37A5FCA1BDBEA6A0027FBD4 /* radiant-player-mac-dsa-pub.pem */; settings = {ASSET_TAGS = (); }; };
+		D37A5FCB1BDBEA6A0027FBD4 /* radiant-player-mac-dsa-pub.pem in Resources */ = {isa = PBXBuildFile; fileRef = D37A5FCA1BDBEA6A0027FBD4 /* radiant-player-mac-dsa-pub.pem */; };
 		D37A5FCD1BDBEAFB0027FBD4 /* radiant-player-mac-dsa-pub.pem in Copy DSA Public Key */ = {isa = PBXBuildFile; fileRef = D37A5FCA1BDBEA6A0027FBD4 /* radiant-player-mac-dsa-pub.pem */; };
 		D37B638418ED315B0098F9DC /* LastFm+TrackInfo.m in Sources */ = {isa = PBXBuildFile; fileRef = D37B638318ED315B0098F9DC /* LastFm+TrackInfo.m */; };
 		D37B638718F1E7680098F9DC /* SpriteDownloadURLProtocol.m in Sources */ = {isa = PBXBuildFile; fileRef = D37B638618F1E7680098F9DC /* SpriteDownloadURLProtocol.m */; };
@@ -78,6 +78,7 @@
 		D3F14A4918F357AA007D4536 /* AdvancedPreferencesViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = D3F14A4818F357AA007D4536 /* AdvancedPreferencesViewController.m */; };
 		D3FAC6D418BA81EC00D9F461 /* PopupStatusView.m in Sources */ = {isa = PBXBuildFile; fileRef = D3FAC6D318BA81EC00D9F461 /* PopupStatusView.m */; };
 		D3FAC6D718BA942500D9F461 /* PopupViewDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = D3FAC6D618BA942500D9F461 /* PopupViewDelegate.m */; };
+		FF76BDFF1C05083D0004D31A /* DarkCyanStyle.m in Sources */ = {isa = PBXBuildFile; fileRef = FF76BDFE1C05083D0004D31A /* DarkCyanStyle.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -230,6 +231,8 @@
 		D3FAC6D318BA81EC00D9F461 /* PopupStatusView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PopupStatusView.m; sourceTree = "<group>"; };
 		D3FAC6D518BA942500D9F461 /* PopupViewDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PopupViewDelegate.h; sourceTree = "<group>"; };
 		D3FAC6D618BA942500D9F461 /* PopupViewDelegate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PopupViewDelegate.m; sourceTree = "<group>"; };
+		FF76BDFD1C05083D0004D31A /* DarkCyanStyle.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DarkCyanStyle.h; sourceTree = "<group>"; };
+		FF76BDFE1C05083D0004D31A /* DarkCyanStyle.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DarkCyanStyle.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -357,6 +360,8 @@
 		D318341818CFC73500E8F9B1 /* Styles */ = {
 			isa = PBXGroup;
 			children = (
+				FF76BDFD1C05083D0004D31A /* DarkCyanStyle.h */,
+				FF76BDFE1C05083D0004D31A /* DarkCyanStyle.m */,
 				D318341918CFC7C500E8F9B1 /* ApplicationStyle.h */,
 				D318341A18CFC7C500E8F9B1 /* ApplicationStyle.m */,
 				B0BB948719F76CF80081C97D /* LightStyle.h */,
@@ -647,6 +652,7 @@
 				D31ACE8A193BDD0F00AC7CB4 /* NotificationCenter.m in Sources */,
 				D362D5421924D17B00FC0C56 /* PrivacyPreferencesViewController.m in Sources */,
 				D37C928C195E3B3F0035709A /* SpotifyBlackStyle.m in Sources */,
+				FF76BDFF1C05083D0004D31A /* DarkCyanStyle.m in Sources */,
 				D343CDF518C69DF4002F9DB3 /* NavigationPreferencesViewController.m in Sources */,
 				D3F14A4918F357AA007D4536 /* AdvancedPreferencesViewController.m in Sources */,
 				D3D4C3E818E76674007238B3 /* LastFmPopover.m in Sources */,

--- a/radiant-player-mac/Styles/ApplicationStyle.m
+++ b/radiant-player-mac/Styles/ApplicationStyle.m
@@ -9,6 +9,7 @@
 
 #import "ApplicationStyle.h"
 #import "SpotifyBlackStyle.h"
+#import "DarkCyanStyle.h"
 #import "SpotifyBlackVibrantStyle.h"
 #import "YosemiteStyle.h"
 #import "LightStyle.h"
@@ -66,6 +67,9 @@
     
     NSMutableDictionary *dictionary = [NSMutableDictionary dictionary];
     [dictionary setObject:spotifyBlack forKey:[spotifyBlack name]];
+
+    DarkCyanStyle *darkCyan = [[DarkCyanStyle alloc] init];
+    [dictionary setObject:darkCyan forKey:[darkCyan name]];
     
 //    if (floor(NSAppKitVersionNumber) > NSAppKitVersionNumber10_9)
 //    {

--- a/radiant-player-mac/Styles/DarkCyanStyle.h
+++ b/radiant-player-mac/Styles/DarkCyanStyle.h
@@ -1,0 +1,14 @@
+/*
+ * DarkCyanStyle.h
+ *
+ * Created by Chris Chrisostomou.
+ *
+ * Subject to terms and conditions in LICENSE.md.
+ *
+ */
+
+#import "ApplicationStyle.h"
+
+@interface DarkCyanStyle : ApplicationStyle
+
+@end

--- a/radiant-player-mac/Styles/DarkCyanStyle.m
+++ b/radiant-player-mac/Styles/DarkCyanStyle.m
@@ -1,0 +1,35 @@
+/*
+ * DarkCyanStyle.m
+ *
+ * Created by Chris Chrisostomou.
+ *
+ * Subject to terms and conditions in LICENSE.md.
+ *
+ */
+
+#import "DarkCyanStyle.h"
+
+@implementation DarkCyanStyle
+
+- (id)init
+{
+    if (self = [super init]) {
+        [self setName:@"Dark Cyan"];
+        [self setAuthor:@"Chris Chrisostomou & Daniel Stuart"];
+        [self setDescription:@"A deep black & cyan style."];
+        [self setWindowColor:[NSColor colorWithSRGBRed:0.133f green:0.137f blue:0.149f alpha:1.0f]];
+        [self setTitleColor:[NSColor colorWithDeviceWhite:0.7f alpha:1.0f]];
+        [self setCss:[ApplicationStyle cssNamed:@"dark-cyan"]];
+        [self setJs:[ApplicationStyle jsNamed:@"dark-cyan"]];
+    }
+    
+    return self;
+}
+
+- (void)applyToWebView:(WebView *)webView window:(NSWindow *)window
+{
+    [self setCss:[NSString stringWithFormat:@"%@%@", [self css], [ApplicationStyle cssNamed:@"spotify-black"]]];
+    [super applyToWebView:webView window:window];
+}
+
+@end

--- a/radiant-player-mac/css/dark-cyan.css
+++ b/radiant-player-mac/css/dark-cyan.css
@@ -1,0 +1,71 @@
+/*
+ * css/dark-cyan.css
+ *
+ * Created by Chris Chrisostomou (https://github.com/chrismou), inspired by an original design by Daniel Stuart (https://github.com/danielstuart14)
+ *
+ * Subject to terms and conditions in LICENSE.md.
+ *
+ */
+
+music-content .info-card sj-paper-button, #music-content .info-card paper-button,
+.top-charts-view .song-row [data-col="index"] .column-content, .material-card .details .left-items .index,
+.more-songs-container,
+paper-toast [data-action="button"],
+paper-toast paper-button[data-action="button"],
+.cluster .lane-button core-icon, .cluster .lane-button iron-icon,
+.material a.primary,
+paper-toggle-button [checked] .toggle-ink,
+paper-input-decorator[focused] .floated-label .label-text,
+paper-checkbox #ink[checked],
+.material-detail-view .material-container-details .read-more-button,
+.material .goog-menu .goog-menuitem.selected .goog-menuitem-content,
+.material .goog-menu .goog-menuitem.selected .goog-menuitem-content:hover,
+paper-input-decorator .floatedLabelText,
+paper-action-dialog sj-paper-button, paper-dialog .buttons paper-button,
+#signup-full .new-user-quiz h1,
+#player.material .material-player-middle sj-icon-button[data-id="play-pause"]:not([disabled]), #player.material .material-player-middle paper-icon-button[data-id="play-pause"]:not([disabled]),
+#player.material .material-player-middle sj-icon-button[data-id="repeat"][value="LIST_REPEAT"], #player.material .material-player-middle sj-icon-button[data-id="repeat"][value="SINGLE_REPEAT"], #player.material .material-player-middle sj-icon-button[data-id="shuffle"][value="ALL_SHUFFLE"], #player.material #material-player-right-wrapper sj-icon-button[data-id="queue"].opened, #player.material .material-player-middle paper-icon-button[data-id="repeat"][value="LIST_REPEAT"], #player.material .material-player-middle paper-icon-button[data-id="repeat"][value="SINGLE_REPEAT"], #player.material .material-player-middle paper-icon-button[data-id="shuffle"][value="ALL_SHUFFLE"], #player.material #material-player-right-wrapper paper-icon-button[data-id="queue"].opened,
+.material .nav-item-container.selected,
+.nav-item-container.selected core-icon, .nav-item-container.selected iron-icon,
+.material .song-row [data-col="radio"],
+.ups.light core-icon, .ups.light iron-icon,
+paper-slider#sliderBar paper-ripple.paper-slider,
+.material .song-table .song-row.currently-playing td
+{
+    color: #039cac!important;
+}
+
+.music-source-list::-webkit-scrollbar-thumb,
+sj-paper-button.material-primary, paper-button.material-primary,
+button.primary,
+paper-button.material-primary[no-focus],
+paper-toggle-button [checked] .toggle,
+paper-input-decorator #underline .focused-underline,
+paper-checkbox #checkbox.checked,
+#material-app-bar,
+paper-slider #sliderBar #activeProgress,
+paper-slider#material-player-progress #sliderContainer.disabled #sliderBar #activeProgress,
+paper-slider.paper-slider-0 #sliderKnobInner.paper-slider,
+paper-progress.paper-slider #primaryProgress.paper-progress,
+.material-drag .song-drag-label,
+.material-transfer-radial-upload-overlay, .material-transfer-radial-download-overlay, .material-transfer-radial-processing-overlay,
+#current-loading-progress {
+    background-color: #039cac!important;
+}
+
+paper-checkbox #checkbox.checked,
+#loading-overlay.material paper-spinner .circle,
+paper-action-dialog.get-link .content paper-spinner .circle,
+.delete-library-dialog .delete-in-progress paper-spinner .circle, .delete-recommendations-dialog .delete-in-progress paper-spinner .circle,
+.nav-section .selected
+{
+    border-color: #039cac!important;
+}
+
+.material-container-details sj-fab, .material-container-details paper-fab {
+    background: #039cac!important;
+}
+
+paper-header-panel#content-container.transparent #material-app-bar {
+    background-color: rgba(3, 166, 181, 0.4)!important;
+}

--- a/radiant-player-mac/css/spotify-black.css
+++ b/radiant-player-mac/css/spotify-black.css
@@ -117,8 +117,11 @@ a, .simple-dialog a {
     border-color: transparent transparent rgba(18, 19, 20, 0.98) rgba(18, 19, 20, 0.98);
 }
 
-.material-detail-view .artist-details {
-    background-color: rgba(18, 19, 20, 0.9);
+.material-album-container.material-container, 
+.material-detail-view .artist-details, 
+.material-container-details, 
+.material-container-details .info {
+    background-color: rgba(18, 19, 20, 0.8)!important;
     color: white;
 }
 

--- a/radiant-player-mac/info.plist
+++ b/radiant-player-mac/info.plist
@@ -34,26 +34,26 @@
 	<dict>
 		<key>NSExceptionDomains</key>
 		<dict>
-			<key>ws.audioscrobbler.com</key>
-			<dict>
-				<key>NSExceptionRequiresForwardSecrecy</key>
-				<false/>
-			</dict>
 			<key>last.fm</key>
 			<dict>
 				<key>NSExceptionAllowsInsecureHTTPLoads</key>
 				<true/>
-				<key>NSIncludesSubdomains</key>
-				<true/>
 				<key>NSExceptionRequiresForwardSecrecy</key>
 				<false/>
+				<key>NSIncludesSubdomains</key>
+				<true/>
 			</dict>
 			<key>lst.fm</key>
 			<dict>
 				<key>NSExceptionAllowsInsecureHTTPLoads</key>
 				<true/>
+				<key>NSExceptionRequiresForwardSecrecy</key>
+				<false/>
 				<key>NSIncludesSubdomains</key>
 				<true/>
+			</dict>
+			<key>ws.audioscrobbler.com</key>
+			<dict>
 				<key>NSExceptionRequiresForwardSecrecy</key>
 				<false/>
 			</dict>

--- a/radiant-player-mac/js/styles/dark-cyan.js
+++ b/radiant-player-mac/js/styles/dark-cyan.js
@@ -1,0 +1,13 @@
+/*
+ * js/styles/dark-cyan.js
+ *
+ * This script contains code needed for the Dark Cyan style.
+ *
+ * Subject to terms and conditions in LICENSE.md.
+ *
+ */
+
+if (typeof window.Styles.Applied === 'undefined') {
+    window.Styles.Applied = true;
+    window.Styles.DarkCyan = true;
+}


### PR DESCRIPTION
This PR adds a new DarkCyan theme, inspired by the work done by @danielstuart14 in https://github.com/radiant-player/radiant-player-mac/pull/348 .  Unfortunately, it required an almost ground up rewrite, although now it extends the default Dark theme (rather than just including a copy/paste of the original CSS) meaning that future CSS fixes in response to layout changes should only need to be made in one place.

The work put into this also opens the door to another idea I'm playing with - namely, being able to set your own custom colours - although that may not make an appearance for a little while.

If you spot any missed elements, let me know and I'll take a look!

Edit: To make it simpler, I've set up a release on my fork and attached a binary - save you booting up Xcode :-)  https://github.com/chrismou/radiant-player-mac/releases/download/v1.5.0-cyan/RadiantPlayer.app.zip