### PR TITLE
Fix for random unloving/loving of tracks on last.fm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,14 +5,18 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 ### Added
+* Added Dark Cyan theme ([#424](https://github.com/radiant-player/radiant-player-mac/pull/424))
 * Added [contribution guidelines](https://github.com/radiant-player/radiant-player-mac/blob/master/CONTRIBUTING.md) for anyone wanting to contribute code to Radiant ([#401](https://github.com/radiant-player/radiant-player-mac/pull/401))
 
 ### Changed
 * Updated to work with Google's latest updates ([#397](https://github.com/radiant-player/radiant-player-mac/pull/397))
 
 ### Fixed
+* Fixed tracks being "randomly" loved/unloved on last.fm ([#426](https://github.com/radiant-player/radiant-player-mac/pull/426))
+* Fixed Spotify layout ([#424](https://github.com/radiant-player/radiant-player-mac/pull/424))
+* Fixed header element names ([#418](https://github.com/radiant-player/radiant-player-mac/pull/418)) (Thanks [@jcurtis](https://github.com/jcurtis))
 * Fixed broken notifications and mini-player updates ([#400](https://github.com/radiant-player/radiant-player-mac/pull/400))
-* Fixed crash when opening Last.fm history by allowing communication with Last.fm API servers ([#389](https://github.com/radiant-player/radiant-player-mac/pull/389), ([#400](https://github.com/radiant-player/radiant-player-mac/pull/400)))
+* Fixed crash when opening Last.fm history by allowing communication with Last.fm API servers ([#389](https://github.com/radiant-player/radiant-player-mac/pull/389), [#400](https://github.com/radiant-player/radiant-player-mac/pull/400))
 * Restored the ability to move the window by the title bar ([#413](https://github.com/radiant-player/radiant-player-mac/pull/413))
 * Fixed broken keyboard shortcut for search ([#413](https://github.com/radiant-player/radiant-player-mac/pull/413))
 

--- a/radiant-player-mac/js/main.js
+++ b/radiant-player-mac/js/main.js
@@ -242,11 +242,7 @@ if (typeof window.MusicAPI === 'undefined') {
                 var target = m.addedNodes[i];
                 var name = target.id || target.className;
 
-                if (name == 'now-playing-info-wrapper')  {
-                    
-                    // Fire the rating observer if the thumbs exist (no harm if already observing)
-                    GoogleMusicApp.ratingChanged(MusicAPI.Rating.getRating());
-                    
+                if (name == 'now-playing-info-wrapper')  {                    
                     var now = new Date();
 
                     var title = document.querySelector('#player #player-song-title');
@@ -274,6 +270,10 @@ if (typeof window.MusicAPI === 'undefined') {
                         lastArtist = artist;
                         lastAlbum = album;
                     }
+
+                    // Fire the rating observer if the thumbs exist (no harm if already observing)
+                    // Ensure this is below notifySong, otherwise it'll apply the loved status of the current song to the previous song (#390)
+                    GoogleMusicApp.ratingChanged(MusicAPI.Rating.getRating());
                 }
             }
         });


### PR DESCRIPTION
See https://github.com/radiant-player/radiant-player-mac/issues/390

Essentially, the rating observer was being called before the track info was updated, meaning that for every song it was applying the loved status of the previous song.  This PR should fix that.

I've logged a separate issue at https://github.com/radiant-player/radiant-player-mac/issues/425 to look into stopping the multiple unnecessarily api calls at the start of every song.