### PR TITLE
Finer grained control over the percentage of the song before scrobbling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 * Added Dark Cyan theme ([#424](https://github.com/radiant-player/radiant-player-mac/pull/424))
 * Added [contribution guidelines](https://github.com/radiant-player/radiant-player-mac/blob/master/CONTRIBUTING.md) for anyone wanting to contribute code to Radiant ([#401](https://github.com/radiant-player/radiant-player-mac/pull/401))
+* Added abilty to specify how much of a song has to be listened to before it's scrobbled, between 50-100% (in line with the official last.fm scrobbler) ([428](https://github.com/radiant-player/radiant-player-mac/pull/428))
 
 ### Changed
 * Updated to work with Google's latest updates ([#397](https://github.com/radiant-player/radiant-player-mac/pull/397))

--- a/radiant-player-mac/AppDelegate.m
+++ b/radiant-player-mac/AppDelegate.m
@@ -706,7 +706,7 @@ static CGEventRef event_tap_callback(CGEventTapProxy proxy,
     
     if ([defaults boolForKey:@"lastfm.enabled"])
     {
-        [LastFmService scrobbleSong:currentTitle withArtist:currentArtist album:currentAlbum duration:currentDuration timestamp:currentTimestamp];
+        [LastFmService scrobbleSong:currentTitle withArtist:currentArtist album:currentAlbum duration:currentDuration timestamp:currentTimestamp percentage:[defaults stringForKey:@"lastfm.percentage"]];
         [LastFmService sendNowPlaying:title withArtist:artist album:album duration:duration timestamp:timestamp];
     }
     

--- a/radiant-player-mac/LastFm/LastFmService.h
+++ b/radiant-player-mac/LastFm/LastFmService.h
@@ -28,7 +28,7 @@
 
 - (IBAction)openRecentTracksPage:(id)sender;
 
-+ (void)scrobbleSong:(NSString *)title withArtist:(NSString *)artist album:(NSString *)album duration:(NSTimeInterval)duration timestamp:(NSTimeInterval)timestamp;
++ (void)scrobbleSong:(NSString *)title withArtist:(NSString *)artist album:(NSString *)album duration:(NSTimeInterval)duration timestamp:(NSTimeInterval)timestamp percentage:(NSString *) percentage;
 + (void)sendNowPlaying:(NSString *)title withArtist:(NSString *)artist album:(NSString *)album duration:(NSTimeInterval)duration timestamp:(NSTimeInterval)timestamp;
 + (void)getRecentTracksWithLimit:(NSInteger)limit successHandler:(LastFmReturnBlockWithArray)successHandler failureHandler:(LastFmReturnBlockWithError)failureHandler;
 + (void)loveTrack:(NSString *)title artist:(NSString *)artist successHandler:(LastFmReturnBlockWithDictionary)successHandler failureHandler:(LastFmReturnBlockWithError)failureHandler;

--- a/radiant-player-mac/LastFm/LastFmService.m
+++ b/radiant-player-mac/LastFm/LastFmService.m
@@ -207,11 +207,14 @@
     return nil;
 }
 
-+ (void)scrobbleSong:(NSString *)title withArtist:(NSString *)artist album:(NSString *)album duration:(NSTimeInterval)duration timestamp:(NSTimeInterval)timestamp
++ (void)scrobbleSong:(NSString *)title withArtist:(NSString *)artist album:(NSString *)album duration:(NSTimeInterval)duration timestamp:(NSTimeInterval)timestamp percentage:(NSString *)percentage
 {
     NSTimeInterval curTimestamp = [[NSDate date] timeIntervalSince1970];
+
+    long percent = [percentage integerValue];
+    long scrobbleAt = (duration / 100) * percent;
     
-    if ([title length] && curTimestamp - timestamp >= duration / 2) {
+    if ([title length] && curTimestamp - timestamp >= scrobbleAt) {
         [[LastFm sharedInstance] sendScrobbledTrack:title
                                            byArtist:artist
                                             onAlbum:album
@@ -225,8 +228,6 @@
                                      }
          ];
     }
-    
-    
 }
 
 + (void)sendNowPlaying:(NSString *)title withArtist:(NSString *)artist album:(NSString *)album duration:(NSTimeInterval)duration timestamp:(NSTimeInterval)timestamp

--- a/radiant-player-mac/Preferences.plist
+++ b/radiant-player-mac/Preferences.plist
@@ -10,6 +10,8 @@
 	<string>ad07b22035670943a1f958159f7c19da</string>
 	<key>lastfm.enabled</key>
 	<false/>
+	<key>lastfm.percentage</key>
+	<string>50</string>
 	<key>lastfm.button.enabled</key>
 	<false/>
 	<key>lastfm.thumbsup.enabled</key>

--- a/radiant-player-mac/Preferences/LastFmPreferencesViewController.h
+++ b/radiant-player-mac/Preferences/LastFmPreferencesViewController.h
@@ -24,4 +24,7 @@
 - (IBAction) authorizeScrobble:(id)sender;
 - (void) sync;
 
+@property (strong) IBOutlet NSSlider *scrobblingPercent;
+@property (weak) IBOutlet NSTextField *scrobblingPercentLabel;
+
 @end

--- a/radiant-player-mac/Preferences/LastFmPreferencesViewController.m
+++ b/radiant-player-mac/Preferences/LastFmPreferencesViewController.m
@@ -14,6 +14,7 @@
 @synthesize authorizeButton;
 @synthesize usernameField;
 @synthesize passwordField;
+@synthesize scrobblingPercentLabel;
 @synthesize logo;
 
 @synthesize defaults;
@@ -27,6 +28,8 @@
     
     // Synchronize the settings.
     [self sync];
+
+    [scrobblingPercentLabel setStringValue: self.scrobblingPercentageString];
 }
 
 - (void) sync
@@ -111,6 +114,17 @@
 - (NSString *)toolbarItemLabel
 {
     return @"Last.fm";
+}
+
+- (NSString *)scrobblingPercentageString
+{
+    long percent = [self.scrobblingPercent integerValue];
+    NSString *val=[NSString stringWithFormat:@"%lu%%", percent];
+    return val;
+}
+
+- (IBAction)percentageChanged:(id)sender {
+    [scrobblingPercentLabel setStringValue: self.scrobblingPercentageString];
 }
 
 @end

--- a/radiant-player-mac/Preferences/PreferencesWindowController.xib
+++ b/radiant-player-mac/Preferences/PreferencesWindowController.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="8191" systemVersion="14E46" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="9060" systemVersion="15B42" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="8191"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="9060"/>
     </dependencies>
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="PreferencesWindowController">
@@ -23,6 +23,7 @@
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="kP2-c6-sUP">
                     <rect key="frame" x="18" y="367" width="105" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                    <animations/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Notifications:" id="BLl-CP-SxA">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -32,6 +33,7 @@
                 <button id="Dew-bn-PGn">
                     <rect key="frame" x="127" y="365" width="333" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                    <animations/>
                     <buttonCell key="cell" type="check" title="Display notification when song changes" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="Qb9-rA-qYZ">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -43,6 +45,7 @@
                 <button id="BA4-pG-D4J">
                     <rect key="frame" x="127" y="338" width="333" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                    <animations/>
                     <buttonCell key="cell" type="check" title="Use Growl for notifications" bezelStyle="regularSquare" imagePosition="left" inset="2" id="JTn-91-56Z">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -55,6 +58,7 @@
                 <button id="XVx-UD-G6n">
                     <rect key="frame" x="127" y="311" width="333" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                    <animations/>
                     <buttonCell key="cell" type="check" title="Include album art in notification" bezelStyle="regularSquare" imagePosition="left" inset="2" id="Y8s-G0-q23">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -75,6 +79,7 @@
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="wI0-wb-A0h">
                     <rect key="frame" x="18" y="229" width="105" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                    <animations/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Mini Player:" id="OVp-Sx-lNi">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -84,6 +89,7 @@
                 <button id="QzZ-lJ-ZC6">
                     <rect key="frame" x="127" y="228" width="333" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                    <animations/>
                     <buttonCell key="cell" type="check" title="Show mini player in menu bar" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="KVZ-cW-hgC">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -95,6 +101,7 @@
                 <button id="8q9-1Z-gSc">
                     <rect key="frame" x="127" y="175" width="333" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                    <animations/>
                     <buttonCell key="cell" type="check" title="Show playing status in mini player icon" bezelStyle="regularSquare" imagePosition="left" inset="2" id="yf5-1F-e4y">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -107,6 +114,7 @@
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" setsMaxLayoutWidthAtFirstLayout="YES" id="Ewn-Vn-Jf4">
                     <rect key="frame" x="146" y="199" width="314" height="29"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                    <animations/>
                     <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" title="Changing this preference will require a restart of the application to take effect" id="7lz-27-vG3">
                         <font key="font" metaFont="smallSystem"/>
                         <color key="textColor" name="disabledControlTextColor" catalog="System" colorSpace="catalog"/>
@@ -116,6 +124,7 @@
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" setsMaxLayoutWidthAtFirstLayout="YES" id="iW3-JM-t6v">
                     <rect key="frame" x="146" y="257" width="314" height="14"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                    <animations/>
                     <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" title="Requires Mac OS X 10.9 or higher" id="oHg-L4-hVc">
                         <font key="font" metaFont="smallSystem"/>
                         <color key="textColor" name="disabledControlTextColor" catalog="System" colorSpace="catalog"/>
@@ -125,6 +134,7 @@
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" setsMaxLayoutWidthAtFirstLayout="YES" id="mPF-4G-rPI">
                     <rect key="frame" x="146" y="296" width="314" height="14"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                    <animations/>
                     <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" title="Requires Mac OS X 10.9 or higher" id="qDC-cN-hCA">
                         <font key="font" metaFont="smallSystem"/>
                         <color key="textColor" name="disabledControlTextColor" catalog="System" colorSpace="catalog"/>
@@ -134,6 +144,7 @@
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" setsMaxLayoutWidthAtFirstLayout="YES" id="V71-OH-XBr">
                     <rect key="frame" x="146" y="119" width="314" height="28"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                    <animations/>
                     <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" title="Access the main menu by right-clicking the menu icon" allowsEditingTextAttributes="YES" id="pkS-R3-Khr">
                         <font key="font" metaFont="smallSystem"/>
                         <color key="textColor" name="alternateSelectedControlColor" catalog="System" colorSpace="catalog"/>
@@ -143,6 +154,7 @@
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" setsMaxLayoutWidthAtFirstLayout="YES" id="asB-JM-HUB">
                     <rect key="frame" x="146" y="105" width="314" height="28"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                    <animations/>
                     <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" title="Changing this preference will require a restart of the application to take effect" allowsEditingTextAttributes="YES" id="M1a-9Q-pog">
                         <font key="font" metaFont="smallSystem"/>
                         <color key="textColor" name="disabledControlTextColor" catalog="System" colorSpace="catalog"/>
@@ -152,6 +164,7 @@
                 <button id="q91-pT-YTA">
                     <rect key="frame" x="127" y="272" width="333" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                    <animations/>
                     <buttonCell key="cell" type="check" title="Use iTunes style notifications" bezelStyle="regularSquare" imagePosition="left" inset="2" id="nox-ZI-U8i">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -172,6 +185,7 @@
                 <button id="JnW-st-Alq">
                     <rect key="frame" x="127" y="148" width="333" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                    <animations/>
                     <buttonCell key="cell" type="check" title="Hide the dock icon when the mini player is active" bezelStyle="regularSquare" imagePosition="left" inset="2" id="x2Z-xf-GDv">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -184,6 +198,7 @@
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="05f-eJ-9L9">
                     <rect key="frame" x="18" y="81" width="105" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                    <animations/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Dock Icon:" id="hCU-za-rf6">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -193,6 +208,7 @@
                 <button id="tQa-56-6R0">
                     <rect key="frame" x="127" y="79" width="333" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                    <animations/>
                     <buttonCell key="cell" type="check" title="Show album art in dock" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="sGR-H1-OiO">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -205,6 +221,7 @@
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="DRs-aQ-9fg">
                     <rect key="frame" x="19" y="52" width="103" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                    <animations/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Updates:" id="IYs-8o-aDY">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -214,6 +231,7 @@
                 <button id="0sK-A0-tA8">
                     <rect key="frame" x="127" y="51" width="333" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                    <animations/>
                     <buttonCell key="cell" type="check" title="Automatically check for updates" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="ZzK-wa-l8x">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -225,6 +243,7 @@
                 <button id="wD5-YM-9ef">
                     <rect key="frame" x="127" y="26" width="333" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                    <animations/>
                     <buttonCell key="cell" type="check" title="Automatically download updates" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="Qje-KO-S7L">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -238,6 +257,7 @@
                     </connections>
                 </button>
             </subviews>
+            <animations/>
             <point key="canvasLocation" x="260" y="280"/>
         </customView>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
@@ -248,6 +268,7 @@
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="SCo-65-NqE">
                     <rect key="frame" x="18" y="52" width="83" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                    <animations/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Appearance:" id="q47-FP-1Ro">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -257,6 +278,7 @@
                 <button id="hgY-IX-Stx">
                     <rect key="frame" x="105" y="50" width="333" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                    <animations/>
                     <buttonCell key="cell" type="check" title="Use custom application appearance" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="8Ld-sp-HDA">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -268,6 +290,7 @@
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" setsMaxLayoutWidthAtFirstLayout="YES" id="VL8-gZ-dPu">
                     <rect key="frame" x="18" y="86" width="326" height="28"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                    <animations/>
                     <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" alignment="center" title="Changing these preferences will require a restart of the application to take effect" id="z4T-NV-tMN">
                         <font key="font" metaFont="smallSystem"/>
                         <color key="textColor" name="disabledControlTextColor" catalog="System" colorSpace="catalog"/>
@@ -277,6 +300,7 @@
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="yZz-74-VDm">
                     <rect key="frame" x="-2" y="22" width="103" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                    <animations/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Style:" id="IEE-Nf-LIX">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -286,6 +310,7 @@
                 <box verticalHuggingPriority="750" title="Box" boxType="separator" titlePosition="noTitle" id="zhW-EN-10a">
                     <rect key="frame" x="12" y="75" width="338" height="5"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                    <animations/>
                     <color key="borderColor" white="0.0" alpha="0.41999999999999998" colorSpace="calibratedWhite"/>
                     <color key="fillColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                     <font key="titleFont" metaFont="system"/>
@@ -293,6 +318,7 @@
                 <popUpButton verticalHuggingPriority="750" id="DeQ-rh-16G">
                     <rect key="frame" x="105" y="17" width="248" height="26"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                    <animations/>
                     <popUpButtonCell key="cell" type="push" title="Item 1" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" arrowPosition="arrowAtCenter" selectedItem="YVY-Hd-cdu" id="SuW-cx-g3z">
                         <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
                         <font key="font" metaFont="menu"/>
@@ -316,6 +342,7 @@
                     </connections>
                 </popUpButton>
             </subviews>
+            <animations/>
         </customView>
         <customObject id="Qr1-oe-yDR" customClass="SUUpdater"/>
         <viewController id="l7y-90-Hoh" customClass="GeneralPreferencesViewController">
@@ -338,6 +365,8 @@
                 <outlet property="authorizeButton" destination="Xdb-Xz-u5h" id="6Zd-7l-7by"/>
                 <outlet property="logo" destination="UIE-Fx-6GJ" id="cQA-Ux-l4b"/>
                 <outlet property="passwordField" destination="i2g-5K-Cl4" id="OzG-or-Fl7"/>
+                <outlet property="scrobblingPercent" destination="AH3-Ok-1RM" id="Scw-cd-Dwd"/>
+                <outlet property="scrobblingPercentLabel" destination="Uhz-9B-Xo4" id="YqH-Sh-hgC"/>
                 <outlet property="usernameField" destination="jsE-zR-hLS" id="jE3-32-FXk"/>
                 <outlet property="view" destination="uPE-UJ-Mvs" id="VFL-pG-hWF"/>
             </connections>
@@ -363,6 +392,7 @@
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="rDq-Nn-Fr7">
                     <rect key="frame" x="18" y="136" width="104" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                    <animations/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Back/Forward:" id="mg0-Oo-WdO">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -372,6 +402,7 @@
                 <button id="EDO-24-zbN">
                     <rect key="frame" x="126" y="105" width="334" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                    <animations/>
                     <buttonCell key="cell" type="check" title="Add back and forward buttons to application bar" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="MWt-RZ-95e">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -383,6 +414,7 @@
                 <button id="RM0-yC-8Bq">
                     <rect key="frame" x="126" y="134" width="334" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                    <animations/>
                     <buttonCell key="cell" type="check" title="Enable swipe gestures to go back and forward" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="wNl-8H-oix">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -394,6 +426,7 @@
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" setsMaxLayoutWidthAtFirstLayout="YES" id="z68-o1-jqs">
                     <rect key="frame" x="144" y="74" width="316" height="29"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                    <animations/>
                     <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" title="Changing this preference will require a restart of the application to take effect" id="Qso-vW-SGy">
                         <font key="font" metaFont="smallSystem"/>
                         <color key="textColor" name="disabledControlTextColor" catalog="System" colorSpace="catalog"/>
@@ -403,6 +436,7 @@
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" setsMaxLayoutWidthAtFirstLayout="YES" id="r7b-Tp-vVw">
                     <rect key="frame" x="144" y="20" width="316" height="29"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                    <animations/>
                     <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" title="Changing this preference will require a restart of the application to take effect" id="VMS-2j-c8q">
                         <font key="font" metaFont="smallSystem"/>
                         <color key="textColor" name="disabledControlTextColor" catalog="System" colorSpace="catalog"/>
@@ -412,6 +446,7 @@
                 <button id="6NL-Uj-KNJ">
                     <rect key="frame" x="126" y="50" width="334" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                    <animations/>
                     <buttonCell key="cell" type="check" title="Don't replace the Apps, Notification, Share links" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="Q56-4r-0gE">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -421,20 +456,23 @@
                     </connections>
                 </button>
             </subviews>
+            <animations/>
             <point key="canvasLocation" x="260" y="632.5"/>
         </customView>
         <customView id="uPE-UJ-Mvs" userLabel="Last.fm Preferences">
-            <rect key="frame" x="0.0" y="0.0" width="392" height="305"/>
+            <rect key="frame" x="0.0" y="0.0" width="392" height="360"/>
             <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
             <subviews>
                 <imageView horizontalHuggingPriority="251" verticalHuggingPriority="251" id="qq0-Xb-LVO">
-                    <rect key="frame" x="151" y="15" width="91" height="29"/>
+                    <rect key="frame" x="151" y="16" width="91" height="29"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                    <animations/>
                     <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="proportionallyDown" image="lastfm" id="UIE-Fx-6GJ"/>
                 </imageView>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="P9p-EX-96C">
-                    <rect key="frame" x="18" y="268" width="90" height="17"/>
+                    <rect key="frame" x="18" y="323" width="90" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                    <animations/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Scrobbling:" id="mHZ-3d-Tcw">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -442,8 +480,9 @@
                     </textFieldCell>
                 </textField>
                 <button id="zMA-KR-d9H">
-                    <rect key="frame" x="112" y="267" width="262" height="18"/>
+                    <rect key="frame" x="112" y="322" width="262" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                    <animations/>
                     <buttonCell key="cell" type="check" title="Scrobble songs to Last.fm" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="GwH-Oe-saC">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -455,6 +494,7 @@
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="rvQ-NY-Dl6">
                     <rect key="frame" x="14" y="126" width="90" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                    <animations/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Username:" id="xqT-BO-fjB">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -464,6 +504,7 @@
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="K6O-90-mBb">
                     <rect key="frame" x="14" y="96" width="90" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                    <animations/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Password:" id="3g3-pA-OQf">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -473,6 +514,7 @@
                 <textField verticalHuggingPriority="750" id="jsE-zR-hLS">
                     <rect key="frame" x="110" y="123" width="262" height="22"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                    <animations/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" placeholderString="" drawsBackground="YES" id="eqt-GX-x6K">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
@@ -490,6 +532,7 @@
                 <secureTextField verticalHuggingPriority="750" id="i2g-5K-Cl4">
                     <rect key="frame" x="110" y="93" width="262" height="22"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                    <animations/>
                     <secureTextFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" borderStyle="bezel" placeholderString="" drawsBackground="YES" usesSingleLineMode="YES" id="kdg-ZI-3hD">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
@@ -506,16 +549,10 @@
                         </binding>
                     </connections>
                 </secureTextField>
-                <box verticalHuggingPriority="750" title="Box" boxType="separator" titlePosition="noTitle" id="wli-GL-bJ9">
-                    <rect key="frame" x="12" y="159" width="368" height="5"/>
-                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <color key="borderColor" white="0.0" alpha="0.41999999999999998" colorSpace="calibratedWhite"/>
-                    <color key="fillColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
-                    <font key="titleFont" metaFont="system"/>
-                </box>
                 <button verticalHuggingPriority="750" id="Xdb-Xz-u5h">
-                    <rect key="frame" x="104" y="57" width="274" height="32"/>
+                    <rect key="frame" x="104" y="52" width="274" height="32"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                    <animations/>
                     <buttonCell key="cell" type="push" title="Authorize" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="oIR-4b-3nh">
                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                         <font key="font" metaFont="system"/>
@@ -525,8 +562,9 @@
                     </connections>
                 </button>
                 <button id="ASF-JF-LyR">
-                    <rect key="frame" x="112" y="204" width="262" height="18"/>
+                    <rect key="frame" x="112" y="218" width="262" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                    <animations/>
                     <buttonCell key="cell" type="check" title="Add Last.fm button to main window" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="NQJ-kR-35L">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -536,17 +574,48 @@
                     </connections>
                 </button>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" setsMaxLayoutWidthAtFirstLayout="YES" id="LfQ-P8-Zwq">
-                    <rect key="frame" x="131" y="174" width="243" height="29"/>
+                    <rect key="frame" x="131" y="187" width="243" height="29"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                    <animations/>
                     <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" title="Changing this preference will require a restart of the application to take effect" id="JUV-0K-skW">
                         <font key="font" metaFont="smallSystem"/>
                         <color key="textColor" name="disabledControlTextColor" catalog="System" colorSpace="catalog"/>
                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
-                <button id="WBu-EO-Sau">
-                    <rect key="frame" x="112" y="228" width="262" height="33"/>
+                <box verticalHuggingPriority="750" title="Box" boxType="separator" titlePosition="noTitle" id="wli-GL-bJ9">
+                    <rect key="frame" x="12" y="165" width="368" height="5"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                    <animations/>
+                    <color key="borderColor" white="0.0" alpha="0.41999999999999998" colorSpace="calibratedWhite"/>
+                    <color key="fillColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
+                    <font key="titleFont" metaFont="system"/>
+                </box>
+                <slider verticalHuggingPriority="750" id="AH3-Ok-1RM">
+                    <rect key="frame" x="204" y="294" width="121" height="20"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                    <animations/>
+                    <sliderCell key="cell" alignment="left" minValue="50" maxValue="100" doubleValue="50" tickMarkPosition="above" sliderType="linear" id="rol-26-JR2"/>
+                    <connections>
+                        <action selector="percentageChanged:" target="ekN-Jf-CMK" id="wlA-Hg-NPh"/>
+                        <binding destination="qKJ-ks-0kW" name="enabled" keyPath="values.lastfm.enabled" id="mV8-YJ-GPU"/>
+                        <binding destination="qKJ-ks-0kW" name="value" keyPath="values.lastfm.percentage" id="41I-5v-Av2"/>
+                    </connections>
+                </slider>
+                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="qpn-Mm-Shc">
+                    <rect key="frame" x="115" y="295" width="94" height="17"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                    <animations/>
+                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Scrobble after:" id="0f2-vL-pL4">
+                        <font key="font" metaFont="smallSystem"/>
+                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                    </textFieldCell>
+                </textField>
+                <button id="WBu-EO-Sau">
+                    <rect key="frame" x="112" y="249" width="262" height="33"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                    <animations/>
                     <buttonCell key="cell" type="check" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="3im-yn-8E8">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <string key="title">Automatically love a track on Last.fm
@@ -557,7 +626,27 @@ when the track is rated "thumbs up"</string>
                         <binding destination="qKJ-ks-0kW" name="value" keyPath="values.lastfm.thumbsup.enabled" id="2EL-XQ-yfD"/>
                     </connections>
                 </button>
+                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="Uhz-9B-Xo4">
+                    <rect key="frame" x="329" y="298" width="31" height="17"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                    <animations/>
+                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="50%" id="TNi-k8-dvd">
+                        <font key="font" metaFont="system"/>
+                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                    </textFieldCell>
+                </textField>
             </subviews>
+            <animations/>
+            <attributedString key="userComments">
+                <fragment content="labels">
+                    <attributes>
+                        <font key="NSFont" metaFont="smallSystem"/>
+                        <paragraphStyle key="NSParagraphStyle" alignment="natural" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
+                    </attributes>
+                </fragment>
+            </attributedString>
+            <point key="canvasLocation" x="290" y="731"/>
         </customView>
         <arrayController id="spz-iP-VP0" userLabel="Styles Array Controller">
             <connections>
@@ -572,6 +661,7 @@ when the track is rated "thumbs up"</string>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="qWk-vH-9cR">
                     <rect key="frame" x="18" y="171" width="100" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                    <animations/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Cookies:" id="b75-4b-w2H">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -581,6 +671,7 @@ when the track is rated "thumbs up"</string>
                 <button id="YOn-dK-BFZ">
                     <rect key="frame" x="122" y="170" width="280" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                    <animations/>
                     <buttonCell key="cell" type="check" title="Use Safari's cookies" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="e3e-kC-VHb">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -592,6 +683,7 @@ when the track is rated "thumbs up"</string>
                 <button id="89y-3h-8Ff">
                     <rect key="frame" x="122" y="114" width="280" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                    <animations/>
                     <buttonCell key="cell" type="check" title="Don't save Radiant Player's cookies" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="2Rr-id-zPZ">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -609,6 +701,7 @@ when the track is rated "thumbs up"</string>
                 <button verticalHuggingPriority="750" id="IjT-rf-SXr">
                     <rect key="frame" x="118" y="45" width="288" height="32"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                    <animations/>
                     <buttonCell key="cell" type="push" title="Remove all stored cookies" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="f4y-nG-Ryi">
                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                         <font key="font" metaFont="system"/>
@@ -620,6 +713,7 @@ when the track is rated "thumbs up"</string>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" setsMaxLayoutWidthAtFirstLayout="YES" id="lMI-8d-fde">
                     <rect key="frame" x="18" y="229" width="384" height="14"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                    <animations/>
                     <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" alignment="center" title="Changing these preference may log you out of Google Play Music" id="Zwl-r2-vbh">
                         <font key="font" metaFont="smallSystem"/>
                         <color key="textColor" name="disabledControlTextColor" catalog="System" colorSpace="catalog"/>
@@ -629,6 +723,7 @@ when the track is rated "thumbs up"</string>
                 <box verticalHuggingPriority="750" title="Box" boxType="separator" titlePosition="noTitle" id="JjR-H1-mF0">
                     <rect key="frame" x="12" y="198" width="396" height="5"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                    <animations/>
                     <color key="borderColor" white="0.0" alpha="0.41999999999999998" colorSpace="calibratedWhite"/>
                     <color key="fillColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                     <font key="titleFont" metaFont="system"/>
@@ -636,6 +731,7 @@ when the track is rated "thumbs up"</string>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" setsMaxLayoutWidthAtFirstLayout="YES" id="bbw-AT-mXA">
                     <rect key="frame" x="141" y="86" width="261" height="28"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                    <animations/>
                     <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" title="Enabling this preference will require you to log in every time you open Radiant Player" id="Q6P-fR-pZS">
                         <font key="font" metaFont="smallSystem"/>
                         <color key="textColor" name="disabledControlTextColor" catalog="System" colorSpace="catalog"/>
@@ -645,6 +741,7 @@ when the track is rated "thumbs up"</string>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" setsMaxLayoutWidthAtFirstLayout="YES" id="LaR-gk-kZT">
                     <rect key="frame" x="141" y="140" width="261" height="28"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                    <animations/>
                     <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" title="Changing this preference will require a restart of the application to take effect" id="inZ-bd-JZT">
                         <font key="font" metaFont="smallSystem"/>
                         <color key="textColor" name="disabledControlTextColor" catalog="System" colorSpace="catalog"/>
@@ -654,6 +751,7 @@ when the track is rated "thumbs up"</string>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" setsMaxLayoutWidthAtFirstLayout="YES" id="BUy-lx-3Vm">
                     <rect key="frame" x="122" y="20" width="280" height="28"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                    <animations/>
                     <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" title="This will clear all cookies stored by Radiant Player and will force a log out" id="XAY-l9-IEt">
                         <font key="font" metaFont="smallSystem"/>
                         <color key="textColor" name="disabledControlTextColor" catalog="System" colorSpace="catalog"/>
@@ -663,6 +761,7 @@ when the track is rated "thumbs up"</string>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="V8F-zm-sdI">
                     <rect key="frame" x="18" y="209" width="384" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                    <animations/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="These preferences require Mac OS X 10.9 or higher" id="hz2-wh-sIU">
                         <font key="font" metaFont="smallSystemBold"/>
                         <color key="textColor" name="disabledControlTextColor" catalog="System" colorSpace="catalog"/>
@@ -670,6 +769,7 @@ when the track is rated "thumbs up"</string>
                     </textFieldCell>
                 </textField>
             </subviews>
+            <animations/>
         </customView>
         <customView id="csb-l7-N8T" userLabel="Advanced Preferences">
             <rect key="frame" x="0.0" y="0.0" width="474" height="114"/>
@@ -678,6 +778,7 @@ when the track is rated "thumbs up"</string>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="GVf-gF-iGo">
                     <rect key="frame" x="18" y="77" width="106" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                    <animations/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Media Keys:" id="auw-Ok-dzZ">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -687,6 +788,7 @@ when the track is rated "thumbs up"</string>
                 <button id="DH3-VL-aO6">
                     <rect key="frame" x="128" y="76" width="328" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                    <animations/>
                     <buttonCell key="cell" type="check" title="Use alternative method to listen for media keys" bezelStyle="regularSquare" imagePosition="left" inset="2" id="Qkb-8c-2vy">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -698,6 +800,7 @@ when the track is rated "thumbs up"</string>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" setsMaxLayoutWidthAtFirstLayout="YES" id="jcU-kB-wTU">
                     <rect key="frame" x="147" y="20" width="309" height="56"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                    <animations/>
                     <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" id="Y3c-yy-O4p">
                         <font key="font" metaFont="smallSystem"/>
                         <string key="title">Required for some applications to work properly, like Adobe Fireworks, but will break Quick Look.
@@ -707,6 +810,7 @@ Changing this preference will require a restart of the application to take effec
                     </textFieldCell>
                 </textField>
             </subviews>
+            <animations/>
         </customView>
     </objects>
     <resources>


### PR DESCRIPTION
Addresses #126 - brings in line with the official last.fm scrobbler by adding a control to specify what percentage of a song has to be listened to before it scrobbles (between 50-100%).

Worth noting that this doesn't change the current method for scrobbling - ie, it waits until the next song starts and then decides whether to scrobble based on what percentage of the previous song you listened to - it simply gives you the ability to set that percentage to something other than 50.

Apologies for the influx of ```<animation/>``` tags - Xcode kept adding them whenever I opened the interface designer. Something to do with 7.1.
