### PR TITLE
Some dark theme tweaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 * Fixed tracks being "randomly" loved/unloved on last.fm ([#426](https://github.com/radiant-player/radiant-player-mac/pull/426))
-* Fixed Spotify layout ([#424](https://github.com/radiant-player/radiant-player-mac/pull/424))
+* Fixed Spotify layout ([#424](https://github.com/radiant-player/radiant-player-mac/pull/424), [#431](https://github.com/radiant-player/radiant-player-mac/pull/431))
 * Fixed header element names ([#418](https://github.com/radiant-player/radiant-player-mac/pull/418)) (Thanks [@jcurtis](https://github.com/jcurtis))
 * Fixed broken notifications and mini-player updates ([#400](https://github.com/radiant-player/radiant-player-mac/pull/400))
 * Fixed crash when opening Last.fm history by allowing communication with Last.fm API servers ([#389](https://github.com/radiant-player/radiant-player-mac/pull/389), [#400](https://github.com/radiant-player/radiant-player-mac/pull/400))

--- a/radiant-player-mac/css/spotify-black.css
+++ b/radiant-player-mac/css/spotify-black.css
@@ -216,29 +216,33 @@ a, .simple-dialog a {
     color: transparent !important;
 }
 
-.material .song-row .song-indicator,
-.material .song-row .title-right-items,
-.material .song-row .content,
-.material .song-row .song-indicator[data-playback-status="paused"],
-.material .song-row .song-indicator[data-playback-status="loading"],
-.material .song-row [data-col="index"] .hover-button[data-id="play"],
-.material .song-row [data-col="track"] .hover-button[data-id="play"],
-.material .song-row.selected-song-row .song-indicator,
-.material .song-row.selected-song-row .title-right-items,
-.material .song-row.selected-song-row .content,
-.material .song-row.selected-song-row .song-indicator[data-playback-status="paused"],
-.material .song-row.selected-song-row .song-indicator[data-playback-status="loading"],
-.material .song-row.selected-song-row [data-col="index"] .hover-button[data-id="play"],
-.material .song-row.selected-song-row [data-col="track"] .hover-button[data-id="play"],
-.material .song-row.hover .song-indicator,
-.material .song-row.hover .title-right-items,
-.material .song-row.hover .content,
-.material .song-row.hover .song-indicator[data-playback-status="paused"],
-.material .song-row.hover .song-indicator[data-playback-status="loading"],
-.material .song-row.hover [data-col="index"] .hover-button[data-id="play"],
-.material .song-row.hover [data-col="track"] .hover-button[data-id="play"]
+/*.material .song-row .song-indicator,*/
+/*.material .song-row .content,*/
+/*.material .song-row .song-indicator[data-playback-status="paused"],*/
+/*.material .song-row .song-indicator[data-playback-status="loading"],*/
+/*.material .song-row [data-col="track"] .hover-button[data-id="play"],*/
+/*.material .song-row [data-col="index"] .hover-button[data-id="play"],*/
+/*.material .song-row.selected-song-row .song-indicator,*/
+/*.material .song-row.selected-song-row .title-right-items,*/
+/*.material .song-row.selected-song-row .content,*/
+/*.material .song-row.selected-song-row .song-indicator[data-playback-status="paused"],*/
+/*.material .song-row.selected-song-row .song-indicator[data-playback-status="loading"],*/
+/*.material .song-row.selected-song-row [data-col="index"] .hover-button[data-id="play"],*/
+/*.material .song-row.selected-song-row [data-col="track"] .hover-button[data-id="play"],*/
+/*.material .song-row.hover .song-indicator,*/
+/*.material .song-row.hover .title-right-items,*/
+/*.material .song-row.hover .content,*/
+/*.material .song-row.hover .song-indicator[data-playback-status="paused"],*/
+/*.material .song-row.hover .song-indicator[data-playback-status="loading"],*/
+/*.material .song-row.hover [data-col="index"] .hover-button[data-id="play"],*/
+/*.material .song-row.hover [data-col="track"] .hover-button[data-id="play"],*/
+.material .song-row .title-right-items
 {
     background-color: transparent !important;
+}
+
+.hover-button[data-id="play"], .material .song-row .rating-container.thumbs [data-rating] {
+    cursor:pointer;
 }
 
 .music-banner {
@@ -544,4 +548,13 @@ div.simple-dialog-bg {
 
 .material-card[data-size="small"][data-type="imfl"] .title {
     color: #FFF;
+}
+
+::-webkit-scrollbar {
+    background-color: #222326;
+}
+
+::-webkit-scrollbar-thumb {
+    background-color: #000;
+    border: 0.25em solid #222326;
 }


### PR DESCRIPTION
Reduced overuse of background overrides; add cursor:pointer to hover play/rating buttons. Addresses https://github.com/radiant-player/radiant-player-mac/issues/430

Played some css whack-a-mole, where one fix would break something else, sending me round in circles.  In the end - from what I can tell - it looks like we were being a bit too overzealous in our use of background-color:transparent!important;.  I'm using the dark theme myself, so I've left the removed rules commented out for reference, so if I spot something broken in the next few days I'll know the first place to check.

To test, just click around and make sure none of the hover effects (ie, when you hover over a song row and the play/rating buttons appear) show up with white backgrounds.

In some rare cases, the buttons don't show up at all. If you see this, try right clicking and reload - I have no idea why (yet) but this seems to fix it and looks to be unrelated to this PR.

Also added a cursor change for the play/ratings buttons to bring inline with the web player.