### PR TITLE
Fix CocoaStandard Scripting

### DIFF
--- a/radiant-player-mac/AppleScript/radiant-player-mac.sdef
+++ b/radiant-player-mac/AppleScript/radiant-player-mac.sdef
@@ -1,11 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE dictionary SYSTEM "file://localhost/System/Library/DTDs/sdef.dtd">
 <dictionary title="Radiant Player Terminology" xmlns:xi="http://www.w3.org/2003/XInclude">
-	<xi:include href="file:///System/Library/ScriptingDefinitions/CocoaStandard.sdef" xpointer="xpointer(/dictionary/suite)"/>
+    <xi:include href="file:///System/Library/ScriptingDefinitions/CocoaStandard.sdef" xpointer="xpointer(/dictionary/suite)"/>
     
     <suite name="Radiant Player Suite" code="GMMs" description="The suite specific to Radiant Player for Google Play Music">
-		
-        <class name="application" code="capp" description="Radiant Player's application object">
+        
+        <!-- Dummy file type to make CocoaStandard happy -->
+        <enumeration name="saveable file format" code="savf" hidden="yes">
+            <enumerator name="dummy" code="VTdm" description="Dummy file format" />
+        </enumeration>
+        
+        <class name="application" code="capp" description="Radiant Player's application object" inherits="application">
             <cocoa class="NSApplication"/>
             <property name="current song name" code="Snam" description="name of the currently playing song" type="text">
                 <cocoa key="currentTitle"/>
@@ -28,32 +33,32 @@
         </class>
         
         <command name="back track" code="GMMsbatr" description="reposition to beginning of current track or go to previous track if already at start of current track">
-			<cocoa class="RadiantPlayerScriptCommand"/>
-		</command>
-		<command name="next track" code="GMMsnetr" description="advance to the next track in the current playlist">
-			<cocoa class="RadiantPlayerScriptCommand"/>
-		</command>
-		<command name="playpause" code="GMMsplpa" description="toggle the playing/paused state of the current track">
-			<cocoa class="RadiantPlayerScriptCommand"/>
-		</command>
-		<command name="toggle thumbs up" code="GMMsthup" description="toggle thumbs up for current track">
-			<cocoa class="RadiantPlayerScriptCommand"/>
-		</command>
-		<command name="toggle thumbs down" code="GMMsthdw" description="toggle thumbs down for current track">
-			<cocoa class="RadiantPlayerScriptCommand"/>
-		</command>
-		<command name="toggle shuffle" code="GMMsshfl" description="toggle shuffle on/off">
-			<cocoa class="RadiantPlayerScriptCommand"/>
-		</command>
-		<command name="toggle repeatmode" code="GMMsrpmo" description="toggle repeat mode">
-			<cocoa class="RadiantPlayerScriptCommand"/>
-		</command>
-		<command name="toggle visualization" code="GMMsvisl" description="toggle visualization on/off">
-			<cocoa class="RadiantPlayerScriptCommand"/>
-		</command>
+            <cocoa class="RadiantPlayerScriptCommand"/>
+        </command>
+        <command name="next track" code="GMMsnetr" description="advance to the next track in the current playlist">
+            <cocoa class="RadiantPlayerScriptCommand"/>
+        </command>
+        <command name="playpause" code="GMMsplpa" description="toggle the playing/paused state of the current track">
+            <cocoa class="RadiantPlayerScriptCommand"/>
+        </command>
+        <command name="toggle thumbs up" code="GMMsthup" description="toggle thumbs up for current track">
+            <cocoa class="RadiantPlayerScriptCommand"/>
+        </command>
+        <command name="toggle thumbs down" code="GMMsthdw" description="toggle thumbs down for current track">
+            <cocoa class="RadiantPlayerScriptCommand"/>
+        </command>
+        <command name="toggle shuffle" code="GMMsshfl" description="toggle shuffle on/off">
+            <cocoa class="RadiantPlayerScriptCommand"/>
+        </command>
+        <command name="toggle repeatmode" code="GMMsrpmo" description="toggle repeat mode">
+            <cocoa class="RadiantPlayerScriptCommand"/>
+        </command>
+        <command name="toggle visualization" code="GMMsvisl" description="toggle visualization on/off">
+            <cocoa class="RadiantPlayerScriptCommand"/>
+        </command>
         
         <value-type name="image" code="imag">
             <cocoa class="NSImage" name="Image" />
         </value-type>
-	</suite>
+    </suite>
 </dictionary>


### PR DESCRIPTION
Our scripting definitions did not inherit from `application` (defined in `CocoaStandard.sdef`), which means common commands like `quit` were not getting executed.  This is the source of the bug in #410.

Fixes #186
Fixes #405
Fixes #410