### PR TITLE
Fix CSS for shrinking navigation arrows

### DIFF
--- a/radiant-player-mac/css/navigation.css
+++ b/radiant-player-mac/css/navigation.css
@@ -9,12 +9,15 @@
  *
  */
 
-.gm-nav-button {
+.gm-nav-button, #material-one-left #left-nav-open-button {
     -webkit-align-self: center;
     -ms-flex-item-align: center;
     align-self: center;
-    min-width: 24px;
+    min-width: 40px;
+}
 
+#material-one-left.with-nav {
+  min-width: 300px;
 }
 
 #rp-padding-left {

--- a/radiant-player-mac/js/navigation.js
+++ b/radiant-player-mac/js/navigation.js
@@ -38,6 +38,7 @@ if (typeof window.GMNavigation === 'undefined') {
         forwardButton.addEventListener('click', function() { window.history.forward(); });
         
         // Add the back and forward buttons.
+        openNavButton.parentNode.classList.add("with-nav");
         openNavButton.parentNode.insertBefore(forwardButton, openNavButton.nextSibling);
         openNavButton.parentNode.insertBefore(backButton, openNavButton.nextSibling);
     }


### PR DESCRIPTION
This addresses https://github.com/radiant-player/radiant-player-mac/issues/442, where at narrow widths the navigation arrows would shrink.

This appears to be because `min-width` did not include padding before, and now does. There is 8px of padding on the buttons, so the new value of 40px now includes the left and right padding.

The `.with-nav` class added to the nav container is used to expand the `min-width` when more buttons have been added so the page title doesn't expand into the search bar, but does not apply the style when the additional nav buttons haven't been added.