### PR TITLE
New theme: “Rdiant”

### DIFF
--- a/radiant-player-mac.xcodeproj/project.pbxproj
+++ b/radiant-player-mac.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		2B8FC1C018C9CB0E006D04FF /* radiant-player-mac.sdef in Resources */ = {isa = PBXBuildFile; fileRef = 2B8FC1BF18C9CB0E006D04FF /* radiant-player-mac.sdef */; };
 		2B8FC1C318C9CB16006D04FF /* RadiantPlayerScriptCommand.m in Sources */ = {isa = PBXBuildFile; fileRef = 2B8FC1C218C9CB16006D04FF /* RadiantPlayerScriptCommand.m */; };
 		38D0C36DAD0F40F5A7254224 /* libPods.a in Frameworks */ = {isa = PBXBuildFile; fileRef = BABD1B4DDCC34CB291C66033 /* libPods.a */; };
+		42C12CDD1C1A73C100E5029B /* RdiantStyle.m in Sources */ = {isa = PBXBuildFile; fileRef = 42C12CDC1C1A73C100E5029B /* RdiantStyle.m */; };
 		B06FB3D219F7723500351943 /* LightStyle.m in Sources */ = {isa = PBXBuildFile; fileRef = B0BB948819F76CFD0081C97D /* LightStyle.m */; };
 		D302E13418B561E100CCD18E /* Preferences.plist in Resources */ = {isa = PBXBuildFile; fileRef = D302E13318B561E100CCD18E /* Preferences.plist */; };
 		D3091F6318C32961007C8DCD /* Utilities.m in Sources */ = {isa = PBXBuildFile; fileRef = D3091F6218C32961007C8DCD /* Utilities.m */; };
@@ -127,6 +128,8 @@
 		2B8FC1BF18C9CB0E006D04FF /* radiant-player-mac.sdef */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "radiant-player-mac.sdef"; sourceTree = "<group>"; };
 		2B8FC1C118C9CB16006D04FF /* RadiantPlayerScriptCommand.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RadiantPlayerScriptCommand.h; sourceTree = "<group>"; };
 		2B8FC1C218C9CB16006D04FF /* RadiantPlayerScriptCommand.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RadiantPlayerScriptCommand.m; sourceTree = "<group>"; };
+		42C12CDB1C1A73AB00E5029B /* RdiantStyle.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RdiantStyle.h; sourceTree = "<group>"; };
+		42C12CDC1C1A73C100E5029B /* RdiantStyle.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RdiantStyle.m; sourceTree = "<group>"; };
 		A32790DC482A48E18B516D0B /* Pods.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.xcconfig; path = Pods/Pods.xcconfig; sourceTree = "<group>"; };
 		B0BB948719F76CF80081C97D /* LightStyle.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LightStyle.h; sourceTree = "<group>"; };
 		B0BB948819F76CFD0081C97D /* LightStyle.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LightStyle.m; sourceTree = "<group>"; };
@@ -374,6 +377,8 @@
 				D346173419D907F300017023 /* SpotifyBlackVibrantStyle.m */,
 				D37C9284195DFE870035709A /* YosemiteStyle.h */,
 				D37C9285195DFE870035709A /* YosemiteStyle.m */,
+				42C12CDB1C1A73AB00E5029B /* RdiantStyle.h */,
+				42C12CDC1C1A73C100E5029B /* RdiantStyle.m */,
 			);
 			path = Styles;
 			sourceTree = "<group>";
@@ -631,6 +636,7 @@
 				1A7B685317453E40001E509E /* AppDelegate.m in Sources */,
 				D3DB8FF818BD6A6400ABE93B /* PlaybackSliderCell.m in Sources */,
 				D3FAC6D718BA942500D9F461 /* PopupViewDelegate.m in Sources */,
+				42C12CDD1C1A73C100E5029B /* RdiantStyle.m in Sources */,
 				D3091F6618C3D7C4007C8DCD /* SwipeIndicatorView.m in Sources */,
 				D37C9286195DFE870035709A /* YosemiteStyle.m in Sources */,
 				D3091F6918C40FBD007C8DCD /* SwipeAnimation.m in Sources */,

--- a/radiant-player-mac/Styles/ApplicationStyle.m
+++ b/radiant-player-mac/Styles/ApplicationStyle.m
@@ -13,6 +13,7 @@
 #import "SpotifyBlackVibrantStyle.h"
 #import "YosemiteStyle.h"
 #import "LightStyle.h"
+#import "RdiantStyle.h"
 #import "../AppDelegate.h"
 
 @implementation ApplicationStyle
@@ -70,6 +71,9 @@
 
     DarkCyanStyle *darkCyan = [[DarkCyanStyle alloc] init];
     [dictionary setObject:darkCyan forKey:[darkCyan name]];
+    
+    RdiantStyle *rdiant = [[RdiantStyle alloc] init];
+    [dictionary setObject:rdiant forKey:[rdiant name]];
     
 //    if (floor(NSAppKitVersionNumber) > NSAppKitVersionNumber10_9)
 //    {

--- a/radiant-player-mac/Styles/RdiantStyle.h
+++ b/radiant-player-mac/Styles/RdiantStyle.h
@@ -1,0 +1,14 @@
+/*
+ * RdiantStyle.h
+ *
+ * Created by Andrew Norell.
+ *
+ * Subject to terms and conditions in LICENSE.md.
+ *
+ */
+
+#import "ApplicationStyle.h"
+
+@interface RdiantStyle : ApplicationStyle
+
+@end

--- a/radiant-player-mac/Styles/RdiantStyle.m
+++ b/radiant-player-mac/Styles/RdiantStyle.m
@@ -1,0 +1,35 @@
+/*
+ * RdiantStyle.m
+ *
+ * Created by Andrew Norell.
+ *
+ * Subject to terms and conditions in LICENSE.md.
+ *
+ */
+
+#import "RdiantStyle.h"
+
+@implementation RdiantStyle
+
+- (id)init
+{
+    if (self = [super init]) {
+        [self setName:@"Rdiant"];
+        [self setAuthor:@"Andrew Norell & Carl Schultze"];
+        [self setDescription:@"An homage to the late, great streaming service."];
+        [self setWindowColor:[NSColor colorWithSRGBRed:0.133f green:0.137f blue:0.149f alpha:1.0f]];
+        [self setTitleColor:[NSColor colorWithDeviceWhite:0.7f alpha:1.0f]];
+        [self setCss:[ApplicationStyle cssNamed:@"rdiant"]];
+        [self setJs:[ApplicationStyle jsNamed:@"rdiant"]];
+    }
+    
+    return self;
+}
+
+- (void)applyToWebView:(WebView *)webView window:(NSWindow *)window
+{
+    [self setCss:[NSString stringWithFormat:@"%@%@", [self css], [ApplicationStyle cssNamed:@"rdiant"]]];
+    [super applyToWebView:webView window:window];
+}
+
+@end

--- a/radiant-player-mac/css/rdiant.css
+++ b/radiant-player-mac/css/rdiant.css
@@ -1,0 +1,123 @@
+/*
+* css/rdiant.css
+*
+* Created by Andrew Norell
+*
+* Subject to terms and conditions in LICENSE.md.
+*
+*/
+@import url(https://fonts.googleapis.com/css?family=Open+Sans:300);
+
+body, button,
+input[type=button], input,
+textarea, .top-charts-view .song-row [data-col="index"] .column-content,
+.material-card .details .left-items .index, .button,
+.simple-dialog-buttons button, .download-submit, .goog-menuheader, .now-playing-menu .goog-menuitem .goog-menuitem-content,
+.goog-menuitem-content, #loading-progress-message, .screensaver .collage .text.time, .visualizercard .label, .bar-button .text {
+	font-family: 'Whitney', 'Open Sans', Helvetica, arial, sans-serif;
+}
+.cluster .header .title, .cluster .header .subtitle,
+.material-detail-view .material-container-details .info .title,
+#material-breadcrumbs .tab-text, .material-card .title, .cluster .header .more,
+.situations-content.material .situations-filter .situation-title,
+.situations-filter .filter-description,
+.material-list li .li-content, sj-search-box #input.sj-search-box,
+.material .nav-item-container, .material .nav-section-header,
+.material .song-table, .material .song-row td, .material .upload-progress-row td, .material-detail-view .material-container-details .info .description,
+.material-detail-view .material-container-details .info .container-stats-container .creator-name,
+.material-detail-view .material-container-details .info .container-stats-container .container-stats span,
+paper-button, .material .recommended-header,
+.material-card[data-size="small"][data-type="imfl"] .sub-title,
+.column .material-card[data-size="small"][data-type="imfl"] .title,
+.material-card[data-is-radio="true"][data-is-listen-now="true"] .details a.title,
+.material-card[data-is-listen-now="true"] .reason .reason-text,
+.material-card[data-is-listen-now="true"] .details .description,
+.material .goog-menu .goog-menuitem .goog-menuitem-content,
+.song-table th,
+.song-table [data-col="index"] .column-content, .song-table [data-col="track"] .column-content,
+.tab-content.paper-tab, paper-tabs,
+.material-card[data-is-listen-now="true"][data-size="xlarge"] .title,
+.material-card[data-is-listen-now="true"][data-size="xlarge"] .sub-title,
+.material-card .sub-title, .material-empty .empty-message, .material-empty .empty-submessage,
+.material-detail-view .artist-details .name, .top-tracks .top-tracks-info .top-tracks-header,
+.material-detail-view .artist-details .bio-wrapper .bio,
+.top-charts-view .song-row [data-col="index"] .column-content, .material-card .details .left-items .index,
+#material-player-left-wrapper #playerSongInfo .now-playing-info-wrapper #currently-playing-title,
+#material-player-left-wrapper #playerSongInfo #player-artist, #material-player-left-wrapper #playerSongInfo .player-dash, #material-player-left-wrapper #playerSongInfo .player-album,
+#time_container_current, #time_container_duration,
+#mini-queue-details .playing-from-title, #mini-queue-details .playing-from .album, #mini-queue-details .playing-from
+{
+font-weight: 300;
+}
+body.material {
+background-color:#FFF;
+}
+#material-app-bar {
+box-shadow: 0 0 5px 0 rgba(0, 0, 0, 0.07);
+-webkit-box-shadow: 0 0 5px 0 rgba(0, 0, 0, 0.07);
+-moz-box-shadow: 0 0 5px 0 rgba(0, 0, 0, 0.07);
+-o-box-shadow: 0 0 5px 0 rgba(0, 0, 0, 0.07);
+}
+
+music-content .info-card sj-paper-button, #music-content .info-card paper-button,
+.top-charts-view .song-row [data-col="index"] .column-content, .material-card .details .left-items .index,
+.more-songs-container,
+paper-toast [data-action="button"],
+paper-toast paper-button[data-action="button"],
+.cluster .lane-button core-icon, .cluster .lane-button iron-icon,
+.material a.primary,
+paper-toggle-button [checked] .toggle-ink,
+paper-input-decorator[focused] .floated-label .label-text,
+paper-checkbox #ink[checked],
+.material-detail-view .material-container-details .read-more-button,
+.material .goog-menu .goog-menuitem.selected .goog-menuitem-content,
+.material .goog-menu .goog-menuitem.selected .goog-menuitem-content:hover,
+paper-input-decorator .floatedLabelText,
+paper-action-dialog sj-paper-button, paper-dialog .buttons paper-button,
+#signup-full .new-user-quiz h1,
+#player.material .material-player-middle sj-icon-button[data-id="play-pause"]:not([disabled]), #player.material .material-player-middle paper-icon-button[data-id="play-pause"]:not([disabled]),
+#player.material .material-player-middle sj-icon-button[data-id="repeat"][value="LIST_REPEAT"], #player.material .material-player-middle sj-icon-button[data-id="repeat"][value="SINGLE_REPEAT"], #player.material .material-player-middle sj-icon-button[data-id="shuffle"][value="ALL_SHUFFLE"], #player.material #material-player-right-wrapper sj-icon-button[data-id="queue"].opened, #player.material .material-player-middle paper-icon-button[data-id="repeat"][value="LIST_REPEAT"], #player.material .material-player-middle paper-icon-button[data-id="repeat"][value="SINGLE_REPEAT"], #player.material .material-player-middle paper-icon-button[data-id="shuffle"][value="ALL_SHUFFLE"], #player.material #material-player-right-wrapper paper-icon-button[data-id="queue"].opened,
+.material .nav-item-container.selected,
+.nav-item-container.selected core-icon, .nav-item-container.selected iron-icon,
+.material .song-row [data-col="radio"],
+.ups.light core-icon, .ups.light iron-icon,
+paper-slider#sliderBar paper-ripple.paper-slider,
+.material .song-table .song-row.currently-playing td
+{
+color: #018fd5!important;
+}
+
+.music-source-list::-webkit-scrollbar-thumb,
+sj-paper-button.material-primary, paper-button.material-primary,
+button.primary,
+paper-button.material-primary[no-focus],
+paper-toggle-button [checked] .toggle,
+paper-input-decorator #underline .focused-underline,
+paper-checkbox #checkbox.checked,
+#material-app-bar,
+paper-slider #sliderBar #activeProgress,
+paper-slider#material-player-progress #sliderContainer.disabled #sliderBar #activeProgress,
+paper-slider.paper-slider-0 #sliderKnobInner.paper-slider,
+paper-progress.paper-slider #primaryProgress.paper-progress,
+.material-drag .song-drag-label,
+.material-transfer-radial-upload-overlay, .material-transfer-radial-download-overlay, .material-transfer-radial-processing-overlay,
+#current-loading-progress {
+background-color: #018fd5!important;
+}
+
+paper-checkbox #checkbox.checked,
+#loading-overlay.material paper-spinner .circle,
+paper-action-dialog.get-link .content paper-spinner .circle,
+.delete-library-dialog .delete-in-progress paper-spinner .circle, .delete-recommendations-dialog .delete-in-progress paper-spinner .circle,
+.nav-section .selected
+{
+border-color: #018fd5!important;
+}
+
+.material-container-details sj-fab, .material-container-details paper-fab {
+background: #018fd5!important;
+}
+
+paper-header-panel#content-container.transparent #material-app-bar {
+background-color: rgba(1, 143, 213, 0.4)!important;
+}

--- a/radiant-player-mac/js/styles/rdiant.js
+++ b/radiant-player-mac/js/styles/rdiant.js
@@ -1,0 +1,13 @@
+/*
+ * js/styles/rdiant.js
+ *
+ * This script contains code needed for the Rdiant style.
+ *
+ * Subject to terms and conditions in LICENSE.md.
+ *
+ */
+
+if (typeof window.Styles.Applied === 'undefined') {
+    window.Styles.Applied = true;
+    window.Styles.Rdiant = true;
+}


### PR DESCRIPTION
After the loss of a certain streaming service, I tried out Google Play Music and came across Radiant Player. I really enjoyed this desktop application, and I wanted to create a new theme for it, called "Rdiant." 

The theme is comprised mainly of CSS changes; mostly color, typeface, and font-weight. If the user has the font "Whitney" installed on their computer, it will use that, but otherwise it will fall back to Google's free-to-use "Open Sans" (which is being pulled in by the theme's CSS).

Another significant change the theme makes is that it replaces the application's icon file (only if the theme is enabled). Here’s what the theme's icon looks like: 
![rdiant-icon](https://cloud.githubusercontent.com/assets/794463/11764116/1f13eaf8-a0e9-11e5-9b26-b96703ff2aef.png)

Here's a screenshot of the theme: 
![rdiant](https://cloud.githubusercontent.com/assets/794463/11764136/d6d82578-a0e9-11e5-80d2-71a5225ac875.png)

I've enjoyed this theme, and I hope others will too. Thank you for your consideration!