### PR TITLE
Mini player & scrobbling broken due to element ID change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 * Updated to work with Google's latest updates ([#397](https://github.com/radiant-player/radiant-player-mac/pull/397))
+* Updated referenced selectors to reflect Google's changes ([#446](https://github.com/radiant-player/radiant-player-mac/pull/446))
 
 ### Fixed
 * Fixed tracks being "randomly" loved/unloved on last.fm ([#426](https://github.com/radiant-player/radiant-player-mac/pull/426))

--- a/radiant-player-mac/js/main.js
+++ b/radiant-player-mac/js/main.js
@@ -245,7 +245,7 @@ if (typeof window.MusicAPI === 'undefined') {
                 if (name == 'now-playing-info-wrapper')  {                    
                     var now = new Date();
 
-                    var title = document.querySelector('#player #player-song-title');
+                    var title = document.querySelector('#player #currently-playing-title');
                     var artist = document.querySelector('#player #player-artist');
                     var album = document.querySelector('#player .player-album');
                     var art = document.querySelector('#player #playingAlbumArt');


### PR DESCRIPTION
Looks like Google changed another element id, causing scrobbling to break (title always being pulled through as undefined).  On investigation, it looks like this also broke the mini player.

Fixes #445