### PR TITLE
Add preference to show notifications even when player is in focus

### DIFF
--- a/radiant-player-mac/Notifications/NotificationCenter.m
+++ b/radiant-player-mac/Notifications/NotificationCenter.m
@@ -7,6 +7,7 @@
  *
  */
 
+#import "AppDelegate.h"
 #import "NotificationCenter.h"
 
 NSString *const SONG_NOTIFICATION_NAME = @"SongNotification";
@@ -140,6 +141,17 @@ NSString *const SONG_NOTIFICATION_NAME = @"SongNotification";
     }
     
     [delegate notificationWasActivated:type];
+}
+
+
+- (BOOL)userNotificationCenter:(NSUserNotificationCenter *)center shouldPresentNotification:(NSUserNotification *)notification
+{
+    AppDelegate *appDelegate = (AppDelegate *)[[NSApplication sharedApplication] delegate];
+
+    if ([appDelegate.defaults boolForKey:@"notifications.always-show"]) {
+        return YES;
+    }
+    return NO;
 }
 
 /*

--- a/radiant-player-mac/Preferences.plist
+++ b/radiant-player-mac/Preferences.plist
@@ -34,6 +34,8 @@
 	<true/>
 	<key>notifications.enabled</key>
 	<true/>
+	<key>notifications.always-show</key>
+	<false/>
 	<key>notifications.use-growl</key>
 	<false/>
 	<key>notifications.itunes-style</key>

--- a/radiant-player-mac/Preferences/PreferencesWindowController.xib
+++ b/radiant-player-mac/Preferences/PreferencesWindowController.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="9060" systemVersion="15B42" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="9531" systemVersion="15C50" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="9060"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="9531"/>
     </dependencies>
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="PreferencesWindowController">
@@ -17,13 +17,12 @@
         </customObject>
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customView id="vbX-VO-Vnk" userLabel="General Preferences">
-            <rect key="frame" x="0.0" y="0.0" width="478" height="404"/>
+            <rect key="frame" x="0.0" y="0.0" width="478" height="423"/>
             <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
             <subviews>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="kP2-c6-sUP">
-                    <rect key="frame" x="18" y="367" width="105" height="17"/>
+                    <rect key="frame" x="18" y="386" width="105" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <animations/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Notifications:" id="BLl-CP-SxA">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -31,9 +30,8 @@
                     </textFieldCell>
                 </textField>
                 <button id="Dew-bn-PGn">
-                    <rect key="frame" x="127" y="365" width="333" height="18"/>
+                    <rect key="frame" x="127" y="384" width="333" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <animations/>
                     <buttonCell key="cell" type="check" title="Display notification when song changes" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="Qb9-rA-qYZ">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -42,23 +40,9 @@
                         <binding destination="qKJ-ks-0kW" name="value" keyPath="values.notifications.enabled" id="umm-ey-XH9"/>
                     </connections>
                 </button>
-                <button id="BA4-pG-D4J">
-                    <rect key="frame" x="127" y="338" width="333" height="18"/>
-                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <animations/>
-                    <buttonCell key="cell" type="check" title="Use Growl for notifications" bezelStyle="regularSquare" imagePosition="left" inset="2" id="JTn-91-56Z">
-                        <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
-                        <font key="font" metaFont="system"/>
-                    </buttonCell>
-                    <connections>
-                        <binding destination="l7y-90-Hoh" name="enabled" keyPath="self.isGrowlSupportAvailable" id="fTa-Sn-6sl"/>
-                        <binding destination="qKJ-ks-0kW" name="value" keyPath="values.notifications.use-growl" id="blf-CF-UHx"/>
-                    </connections>
-                </button>
                 <button id="XVx-UD-G6n">
-                    <rect key="frame" x="127" y="311" width="333" height="18"/>
+                    <rect key="frame" x="127" y="303" width="333" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <animations/>
                     <buttonCell key="cell" type="check" title="Include album art in notification" bezelStyle="regularSquare" imagePosition="left" inset="2" id="Y8s-G0-q23">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -77,9 +61,8 @@
                     </connections>
                 </button>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="wI0-wb-A0h">
-                    <rect key="frame" x="18" y="229" width="105" height="17"/>
+                    <rect key="frame" x="18" y="221" width="105" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <animations/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Mini Player:" id="OVp-Sx-lNi">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -87,9 +70,8 @@
                     </textFieldCell>
                 </textField>
                 <button id="QzZ-lJ-ZC6">
-                    <rect key="frame" x="127" y="228" width="333" height="18"/>
+                    <rect key="frame" x="127" y="220" width="333" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <animations/>
                     <buttonCell key="cell" type="check" title="Show mini player in menu bar" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="KVZ-cW-hgC">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -99,9 +81,8 @@
                     </connections>
                 </button>
                 <button id="8q9-1Z-gSc">
-                    <rect key="frame" x="127" y="175" width="333" height="18"/>
+                    <rect key="frame" x="127" y="167" width="333" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <animations/>
                     <buttonCell key="cell" type="check" title="Show playing status in mini player icon" bezelStyle="regularSquare" imagePosition="left" inset="2" id="yf5-1F-e4y">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -112,9 +93,8 @@
                     </connections>
                 </button>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" setsMaxLayoutWidthAtFirstLayout="YES" id="Ewn-Vn-Jf4">
-                    <rect key="frame" x="146" y="199" width="314" height="29"/>
+                    <rect key="frame" x="146" y="191" width="314" height="29"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <animations/>
                     <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" title="Changing this preference will require a restart of the application to take effect" id="7lz-27-vG3">
                         <font key="font" metaFont="smallSystem"/>
                         <color key="textColor" name="disabledControlTextColor" catalog="System" colorSpace="catalog"/>
@@ -122,9 +102,8 @@
                     </textFieldCell>
                 </textField>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" setsMaxLayoutWidthAtFirstLayout="YES" id="iW3-JM-t6v">
-                    <rect key="frame" x="146" y="257" width="314" height="14"/>
+                    <rect key="frame" x="146" y="249" width="314" height="14"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <animations/>
                     <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" title="Requires Mac OS X 10.9 or higher" id="oHg-L4-hVc">
                         <font key="font" metaFont="smallSystem"/>
                         <color key="textColor" name="disabledControlTextColor" catalog="System" colorSpace="catalog"/>
@@ -132,9 +111,8 @@
                     </textFieldCell>
                 </textField>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" setsMaxLayoutWidthAtFirstLayout="YES" id="mPF-4G-rPI">
-                    <rect key="frame" x="146" y="296" width="314" height="14"/>
+                    <rect key="frame" x="146" y="288" width="314" height="14"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <animations/>
                     <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" title="Requires Mac OS X 10.9 or higher" id="qDC-cN-hCA">
                         <font key="font" metaFont="smallSystem"/>
                         <color key="textColor" name="disabledControlTextColor" catalog="System" colorSpace="catalog"/>
@@ -142,9 +120,8 @@
                     </textFieldCell>
                 </textField>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" setsMaxLayoutWidthAtFirstLayout="YES" id="V71-OH-XBr">
-                    <rect key="frame" x="146" y="119" width="314" height="28"/>
+                    <rect key="frame" x="146" y="111" width="314" height="28"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <animations/>
                     <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" title="Access the main menu by right-clicking the menu icon" allowsEditingTextAttributes="YES" id="pkS-R3-Khr">
                         <font key="font" metaFont="smallSystem"/>
                         <color key="textColor" name="alternateSelectedControlColor" catalog="System" colorSpace="catalog"/>
@@ -152,9 +129,8 @@
                     </textFieldCell>
                 </textField>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" setsMaxLayoutWidthAtFirstLayout="YES" id="asB-JM-HUB">
-                    <rect key="frame" x="146" y="105" width="314" height="28"/>
+                    <rect key="frame" x="146" y="97" width="314" height="28"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <animations/>
                     <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" title="Changing this preference will require a restart of the application to take effect" allowsEditingTextAttributes="YES" id="M1a-9Q-pog">
                         <font key="font" metaFont="smallSystem"/>
                         <color key="textColor" name="disabledControlTextColor" catalog="System" colorSpace="catalog"/>
@@ -162,9 +138,8 @@
                     </textFieldCell>
                 </textField>
                 <button id="q91-pT-YTA">
-                    <rect key="frame" x="127" y="272" width="333" height="18"/>
+                    <rect key="frame" x="127" y="264" width="333" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <animations/>
                     <buttonCell key="cell" type="check" title="Use iTunes style notifications" bezelStyle="regularSquare" imagePosition="left" inset="2" id="nox-ZI-U8i">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -183,9 +158,8 @@
                     </connections>
                 </button>
                 <button id="JnW-st-Alq">
-                    <rect key="frame" x="127" y="148" width="333" height="18"/>
+                    <rect key="frame" x="127" y="140" width="333" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <animations/>
                     <buttonCell key="cell" type="check" title="Hide the dock icon when the mini player is active" bezelStyle="regularSquare" imagePosition="left" inset="2" id="x2Z-xf-GDv">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -196,9 +170,8 @@
                     </connections>
                 </button>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="05f-eJ-9L9">
-                    <rect key="frame" x="18" y="81" width="105" height="17"/>
+                    <rect key="frame" x="18" y="73" width="105" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <animations/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Dock Icon:" id="hCU-za-rf6">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -206,9 +179,8 @@
                     </textFieldCell>
                 </textField>
                 <button id="tQa-56-6R0">
-                    <rect key="frame" x="127" y="79" width="333" height="18"/>
+                    <rect key="frame" x="127" y="71" width="333" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <animations/>
                     <buttonCell key="cell" type="check" title="Show album art in dock" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="sGR-H1-OiO">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -219,9 +191,8 @@
                     </connections>
                 </button>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="DRs-aQ-9fg">
-                    <rect key="frame" x="19" y="52" width="103" height="17"/>
+                    <rect key="frame" x="19" y="44" width="103" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <animations/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Updates:" id="IYs-8o-aDY">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -229,9 +200,8 @@
                     </textFieldCell>
                 </textField>
                 <button id="0sK-A0-tA8">
-                    <rect key="frame" x="127" y="51" width="333" height="18"/>
+                    <rect key="frame" x="127" y="43" width="333" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <animations/>
                     <buttonCell key="cell" type="check" title="Automatically check for updates" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="ZzK-wa-l8x">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -241,9 +211,8 @@
                     </connections>
                 </button>
                 <button id="wD5-YM-9ef">
-                    <rect key="frame" x="127" y="26" width="333" height="18"/>
+                    <rect key="frame" x="127" y="18" width="333" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <animations/>
                     <buttonCell key="cell" type="check" title="Automatically download updates" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="Qje-KO-S7L">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -256,9 +225,30 @@
                         <binding destination="Qr1-oe-yDR" name="value" keyPath="automaticallyDownloadsUpdates" id="9Ul-Aq-ZHq"/>
                     </connections>
                 </button>
+                <button id="9fI-8q-UEC">
+                    <rect key="frame" x="127" y="330" width="333" height="18"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                    <buttonCell key="cell" type="check" title="Display notification when song changes" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="7GM-na-Ial">
+                        <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                        <font key="font" metaFont="system"/>
+                    </buttonCell>
+                    <connections>
+                        <binding destination="qKJ-ks-0kW" name="value" keyPath="values.notifications.enabled" id="Bps-ZJ-tlM"/>
+                    </connections>
+                </button>
+                <button id="BA4-pG-D4J">
+                    <rect key="frame" x="127" y="357" width="333" height="18"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                    <buttonCell key="cell" type="check" title="Display notification when player is in focus" bezelStyle="regularSquare" imagePosition="left" inset="2" id="JTn-91-56Z">
+                        <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                        <font key="font" metaFont="system"/>
+                    </buttonCell>
+                    <connections>
+                        <binding destination="qKJ-ks-0kW" name="value" keyPath="values.notifications.always-show" id="LQv-64-VL7"/>
+                    </connections>
+                </button>
             </subviews>
-            <animations/>
-            <point key="canvasLocation" x="260" y="280"/>
+            <point key="canvasLocation" x="260" y="210.5"/>
         </customView>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
         <customView id="D7u-3l-nVG" userLabel="Appearance Preferences">
@@ -268,7 +258,6 @@
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="SCo-65-NqE">
                     <rect key="frame" x="18" y="52" width="83" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <animations/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Appearance:" id="q47-FP-1Ro">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -278,7 +267,6 @@
                 <button id="hgY-IX-Stx">
                     <rect key="frame" x="105" y="50" width="333" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <animations/>
                     <buttonCell key="cell" type="check" title="Use custom application appearance" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="8Ld-sp-HDA">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -290,7 +278,6 @@
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" setsMaxLayoutWidthAtFirstLayout="YES" id="VL8-gZ-dPu">
                     <rect key="frame" x="18" y="86" width="326" height="28"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <animations/>
                     <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" alignment="center" title="Changing these preferences will require a restart of the application to take effect" id="z4T-NV-tMN">
                         <font key="font" metaFont="smallSystem"/>
                         <color key="textColor" name="disabledControlTextColor" catalog="System" colorSpace="catalog"/>
@@ -300,7 +287,6 @@
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="yZz-74-VDm">
                     <rect key="frame" x="-2" y="22" width="103" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <animations/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Style:" id="IEE-Nf-LIX">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -310,7 +296,6 @@
                 <box verticalHuggingPriority="750" title="Box" boxType="separator" titlePosition="noTitle" id="zhW-EN-10a">
                     <rect key="frame" x="12" y="75" width="338" height="5"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <animations/>
                     <color key="borderColor" white="0.0" alpha="0.41999999999999998" colorSpace="calibratedWhite"/>
                     <color key="fillColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                     <font key="titleFont" metaFont="system"/>
@@ -318,7 +303,6 @@
                 <popUpButton verticalHuggingPriority="750" id="DeQ-rh-16G">
                     <rect key="frame" x="105" y="17" width="248" height="26"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <animations/>
                     <popUpButtonCell key="cell" type="push" title="Item 1" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" arrowPosition="arrowAtCenter" selectedItem="YVY-Hd-cdu" id="SuW-cx-g3z">
                         <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
                         <font key="font" metaFont="menu"/>
@@ -342,7 +326,6 @@
                     </connections>
                 </popUpButton>
             </subviews>
-            <animations/>
         </customView>
         <customObject id="Qr1-oe-yDR" customClass="SUUpdater"/>
         <viewController id="l7y-90-Hoh" customClass="GeneralPreferencesViewController">
@@ -386,13 +369,12 @@
         </viewController>
         <userDefaultsController representsSharedInstance="YES" id="qKJ-ks-0kW"/>
         <customView id="Vkx-Or-RjQ" userLabel="Navigation Preferences">
-            <rect key="frame" x="0.0" y="-5" width="478" height="173"/>
+            <rect key="frame" x="0.0" y="0.0" width="478" height="173"/>
             <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
             <subviews>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="rDq-Nn-Fr7">
                     <rect key="frame" x="18" y="136" width="104" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <animations/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Back/Forward:" id="mg0-Oo-WdO">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -402,7 +384,6 @@
                 <button id="EDO-24-zbN">
                     <rect key="frame" x="126" y="105" width="334" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <animations/>
                     <buttonCell key="cell" type="check" title="Add back and forward buttons to application bar" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="MWt-RZ-95e">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -414,7 +395,6 @@
                 <button id="RM0-yC-8Bq">
                     <rect key="frame" x="126" y="134" width="334" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <animations/>
                     <buttonCell key="cell" type="check" title="Enable swipe gestures to go back and forward" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="wNl-8H-oix">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -426,7 +406,6 @@
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" setsMaxLayoutWidthAtFirstLayout="YES" id="z68-o1-jqs">
                     <rect key="frame" x="144" y="74" width="316" height="29"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <animations/>
                     <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" title="Changing this preference will require a restart of the application to take effect" id="Qso-vW-SGy">
                         <font key="font" metaFont="smallSystem"/>
                         <color key="textColor" name="disabledControlTextColor" catalog="System" colorSpace="catalog"/>
@@ -436,7 +415,6 @@
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" setsMaxLayoutWidthAtFirstLayout="YES" id="r7b-Tp-vVw">
                     <rect key="frame" x="144" y="20" width="316" height="29"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <animations/>
                     <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" title="Changing this preference will require a restart of the application to take effect" id="VMS-2j-c8q">
                         <font key="font" metaFont="smallSystem"/>
                         <color key="textColor" name="disabledControlTextColor" catalog="System" colorSpace="catalog"/>
@@ -446,7 +424,6 @@
                 <button id="6NL-Uj-KNJ">
                     <rect key="frame" x="126" y="50" width="334" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <animations/>
                     <buttonCell key="cell" type="check" title="Don't replace the Apps, Notification, Share links" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="Q56-4r-0gE">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -456,7 +433,6 @@
                     </connections>
                 </button>
             </subviews>
-            <animations/>
             <point key="canvasLocation" x="260" y="632.5"/>
         </customView>
         <customView id="uPE-UJ-Mvs" userLabel="Last.fm Preferences">
@@ -466,13 +442,11 @@
                 <imageView horizontalHuggingPriority="251" verticalHuggingPriority="251" id="qq0-Xb-LVO">
                     <rect key="frame" x="151" y="16" width="91" height="29"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <animations/>
                     <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="proportionallyDown" image="lastfm" id="UIE-Fx-6GJ"/>
                 </imageView>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="P9p-EX-96C">
                     <rect key="frame" x="18" y="323" width="90" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <animations/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Scrobbling:" id="mHZ-3d-Tcw">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -482,7 +456,6 @@
                 <button id="zMA-KR-d9H">
                     <rect key="frame" x="112" y="322" width="262" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <animations/>
                     <buttonCell key="cell" type="check" title="Scrobble songs to Last.fm" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="GwH-Oe-saC">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -494,7 +467,6 @@
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="rvQ-NY-Dl6">
                     <rect key="frame" x="14" y="126" width="90" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <animations/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Username:" id="xqT-BO-fjB">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -504,7 +476,6 @@
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="K6O-90-mBb">
                     <rect key="frame" x="14" y="96" width="90" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <animations/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Password:" id="3g3-pA-OQf">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -514,7 +485,6 @@
                 <textField verticalHuggingPriority="750" id="jsE-zR-hLS">
                     <rect key="frame" x="110" y="123" width="262" height="22"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <animations/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" placeholderString="" drawsBackground="YES" id="eqt-GX-x6K">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
@@ -532,7 +502,6 @@
                 <secureTextField verticalHuggingPriority="750" id="i2g-5K-Cl4">
                     <rect key="frame" x="110" y="93" width="262" height="22"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <animations/>
                     <secureTextFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" borderStyle="bezel" placeholderString="" drawsBackground="YES" usesSingleLineMode="YES" id="kdg-ZI-3hD">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
@@ -552,7 +521,6 @@
                 <button verticalHuggingPriority="750" id="Xdb-Xz-u5h">
                     <rect key="frame" x="104" y="52" width="274" height="32"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <animations/>
                     <buttonCell key="cell" type="push" title="Authorize" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="oIR-4b-3nh">
                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                         <font key="font" metaFont="system"/>
@@ -564,7 +532,6 @@
                 <button id="ASF-JF-LyR">
                     <rect key="frame" x="112" y="218" width="262" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <animations/>
                     <buttonCell key="cell" type="check" title="Add Last.fm button to main window" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="NQJ-kR-35L">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -576,7 +543,6 @@
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" setsMaxLayoutWidthAtFirstLayout="YES" id="LfQ-P8-Zwq">
                     <rect key="frame" x="131" y="187" width="243" height="29"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <animations/>
                     <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" title="Changing this preference will require a restart of the application to take effect" id="JUV-0K-skW">
                         <font key="font" metaFont="smallSystem"/>
                         <color key="textColor" name="disabledControlTextColor" catalog="System" colorSpace="catalog"/>
@@ -586,7 +552,6 @@
                 <box verticalHuggingPriority="750" title="Box" boxType="separator" titlePosition="noTitle" id="wli-GL-bJ9">
                     <rect key="frame" x="12" y="165" width="368" height="5"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <animations/>
                     <color key="borderColor" white="0.0" alpha="0.41999999999999998" colorSpace="calibratedWhite"/>
                     <color key="fillColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                     <font key="titleFont" metaFont="system"/>
@@ -594,7 +559,6 @@
                 <slider verticalHuggingPriority="750" id="AH3-Ok-1RM">
                     <rect key="frame" x="204" y="294" width="121" height="20"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <animations/>
                     <sliderCell key="cell" alignment="left" minValue="50" maxValue="100" doubleValue="50" tickMarkPosition="above" sliderType="linear" id="rol-26-JR2"/>
                     <connections>
                         <action selector="percentageChanged:" target="ekN-Jf-CMK" id="wlA-Hg-NPh"/>
@@ -605,7 +569,6 @@
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="qpn-Mm-Shc">
                     <rect key="frame" x="115" y="295" width="94" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <animations/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Scrobble after:" id="0f2-vL-pL4">
                         <font key="font" metaFont="smallSystem"/>
                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -615,7 +578,6 @@
                 <button id="WBu-EO-Sau">
                     <rect key="frame" x="112" y="249" width="262" height="33"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <animations/>
                     <buttonCell key="cell" type="check" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="3im-yn-8E8">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <string key="title">Automatically love a track on Last.fm
@@ -629,7 +591,6 @@ when the track is rated "thumbs up"</string>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="Uhz-9B-Xo4">
                     <rect key="frame" x="329" y="298" width="31" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <animations/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="50%" id="TNi-k8-dvd">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -637,11 +598,10 @@ when the track is rated "thumbs up"</string>
                     </textFieldCell>
                 </textField>
             </subviews>
-            <animations/>
             <attributedString key="userComments">
                 <fragment content="labels">
                     <attributes>
-                        <font key="NSFont" metaFont="smallSystem"/>
+                        <font key="NSFont" metaFont="controlContent" size="11"/>
                         <paragraphStyle key="NSParagraphStyle" alignment="natural" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
                     </attributes>
                 </fragment>
@@ -661,7 +621,6 @@ when the track is rated "thumbs up"</string>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="qWk-vH-9cR">
                     <rect key="frame" x="18" y="171" width="100" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <animations/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Cookies:" id="b75-4b-w2H">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -671,7 +630,6 @@ when the track is rated "thumbs up"</string>
                 <button id="YOn-dK-BFZ">
                     <rect key="frame" x="122" y="170" width="280" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <animations/>
                     <buttonCell key="cell" type="check" title="Use Safari's cookies" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="e3e-kC-VHb">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -683,7 +641,6 @@ when the track is rated "thumbs up"</string>
                 <button id="89y-3h-8Ff">
                     <rect key="frame" x="122" y="114" width="280" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <animations/>
                     <buttonCell key="cell" type="check" title="Don't save Radiant Player's cookies" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="2Rr-id-zPZ">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -701,7 +658,6 @@ when the track is rated "thumbs up"</string>
                 <button verticalHuggingPriority="750" id="IjT-rf-SXr">
                     <rect key="frame" x="118" y="45" width="288" height="32"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <animations/>
                     <buttonCell key="cell" type="push" title="Remove all stored cookies" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="f4y-nG-Ryi">
                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                         <font key="font" metaFont="system"/>
@@ -713,7 +669,6 @@ when the track is rated "thumbs up"</string>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" setsMaxLayoutWidthAtFirstLayout="YES" id="lMI-8d-fde">
                     <rect key="frame" x="18" y="229" width="384" height="14"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <animations/>
                     <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" alignment="center" title="Changing these preference may log you out of Google Play Music" id="Zwl-r2-vbh">
                         <font key="font" metaFont="smallSystem"/>
                         <color key="textColor" name="disabledControlTextColor" catalog="System" colorSpace="catalog"/>
@@ -723,7 +678,6 @@ when the track is rated "thumbs up"</string>
                 <box verticalHuggingPriority="750" title="Box" boxType="separator" titlePosition="noTitle" id="JjR-H1-mF0">
                     <rect key="frame" x="12" y="198" width="396" height="5"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <animations/>
                     <color key="borderColor" white="0.0" alpha="0.41999999999999998" colorSpace="calibratedWhite"/>
                     <color key="fillColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                     <font key="titleFont" metaFont="system"/>
@@ -731,7 +685,6 @@ when the track is rated "thumbs up"</string>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" setsMaxLayoutWidthAtFirstLayout="YES" id="bbw-AT-mXA">
                     <rect key="frame" x="141" y="86" width="261" height="28"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <animations/>
                     <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" title="Enabling this preference will require you to log in every time you open Radiant Player" id="Q6P-fR-pZS">
                         <font key="font" metaFont="smallSystem"/>
                         <color key="textColor" name="disabledControlTextColor" catalog="System" colorSpace="catalog"/>
@@ -741,7 +694,6 @@ when the track is rated "thumbs up"</string>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" setsMaxLayoutWidthAtFirstLayout="YES" id="LaR-gk-kZT">
                     <rect key="frame" x="141" y="140" width="261" height="28"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <animations/>
                     <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" title="Changing this preference will require a restart of the application to take effect" id="inZ-bd-JZT">
                         <font key="font" metaFont="smallSystem"/>
                         <color key="textColor" name="disabledControlTextColor" catalog="System" colorSpace="catalog"/>
@@ -751,7 +703,6 @@ when the track is rated "thumbs up"</string>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" setsMaxLayoutWidthAtFirstLayout="YES" id="BUy-lx-3Vm">
                     <rect key="frame" x="122" y="20" width="280" height="28"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <animations/>
                     <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" title="This will clear all cookies stored by Radiant Player and will force a log out" id="XAY-l9-IEt">
                         <font key="font" metaFont="smallSystem"/>
                         <color key="textColor" name="disabledControlTextColor" catalog="System" colorSpace="catalog"/>
@@ -761,7 +712,6 @@ when the track is rated "thumbs up"</string>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="V8F-zm-sdI">
                     <rect key="frame" x="18" y="209" width="384" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <animations/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="These preferences require Mac OS X 10.9 or higher" id="hz2-wh-sIU">
                         <font key="font" metaFont="smallSystemBold"/>
                         <color key="textColor" name="disabledControlTextColor" catalog="System" colorSpace="catalog"/>
@@ -769,7 +719,6 @@ when the track is rated "thumbs up"</string>
                     </textFieldCell>
                 </textField>
             </subviews>
-            <animations/>
         </customView>
         <customView id="csb-l7-N8T" userLabel="Advanced Preferences">
             <rect key="frame" x="0.0" y="0.0" width="474" height="114"/>
@@ -778,7 +727,6 @@ when the track is rated "thumbs up"</string>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="GVf-gF-iGo">
                     <rect key="frame" x="18" y="77" width="106" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <animations/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Media Keys:" id="auw-Ok-dzZ">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -788,7 +736,6 @@ when the track is rated "thumbs up"</string>
                 <button id="DH3-VL-aO6">
                     <rect key="frame" x="128" y="76" width="328" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <animations/>
                     <buttonCell key="cell" type="check" title="Use alternative method to listen for media keys" bezelStyle="regularSquare" imagePosition="left" inset="2" id="Qkb-8c-2vy">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -800,7 +747,6 @@ when the track is rated "thumbs up"</string>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" setsMaxLayoutWidthAtFirstLayout="YES" id="jcU-kB-wTU">
                     <rect key="frame" x="147" y="20" width="309" height="56"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <animations/>
                     <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" id="Y3c-yy-O4p">
                         <font key="font" metaFont="smallSystem"/>
                         <string key="title">Required for some applications to work properly, like Adobe Fireworks, but will break Quick Look.
@@ -810,7 +756,6 @@ Changing this preference will require a restart of the application to take effec
                     </textFieldCell>
                 </textField>
             </subviews>
-            <animations/>
         </customView>
     </objects>
     <resources>

--- a/radiant-player-mac/en.lproj/MainMenu.xib
+++ b/radiant-player-mac/en.lproj/MainMenu.xib
@@ -296,7 +296,7 @@
             <windowCollectionBehavior key="collectionBehavior" fullScreenPrimary="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" topStrut="YES" bottomStrut="YES"/>
             <rect key="contentRect" x="335" y="390" width="942" height="702"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="2560" height="1417"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="1920" height="1057"/>
             <view key="contentView" id="372">
                 <rect key="frame" x="0.0" y="0.0" width="942" height="702"/>
                 <autoresizingMask key="autoresizingMask"/>
@@ -392,7 +392,7 @@
             <windowStyleMask key="styleMask" titled="YES" closable="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
             <rect key="contentRect" x="131" y="159" width="297" height="293"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="2560" height="1417"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="1920" height="1057"/>
             <value key="minSize" type="size" width="297" height="325"/>
             <value key="maxSize" type="size" width="297" height="325"/>
             <view key="contentView" id="bh6-VI-WVo">
@@ -474,7 +474,7 @@
             <windowCollectionBehavior key="collectionBehavior" moveToActiveSpace="YES" ignoresCycle="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
             <rect key="contentRect" x="139" y="81" width="356" height="152"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="2560" height="1417"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="1920" height="1057"/>
             <view key="contentView" id="4yq-G3-W3B" customClass="PopupView">
                 <rect key="frame" x="0.0" y="0.0" width="356" height="152"/>
                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -540,7 +540,7 @@
                             <constraint firstItem="ngI-Gb-8Jw" firstAttribute="leading" secondItem="QTZ-Jw-ZpH" secondAttribute="leading" id="sYT-Br-7Fg"/>
                         </constraints>
                     </customView>
-                    <button focusRingType="none" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="ftM-je-Ymy">
+                    <button focusRingType="none" translatesAutoresizingMaskIntoConstraints="NO" id="ftM-je-Ymy">
                         <rect key="frame" x="162" y="37" width="32" height="32"/>
                         <constraints>
                             <constraint firstAttribute="width" constant="32" id="2E3-Ii-byb"/>
@@ -554,7 +554,7 @@
                             <action selector="playPause:" target="494" id="mxx-1f-URL"/>
                         </connections>
                     </button>
-                    <button focusRingType="none" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="VkG-Lf-5uN">
+                    <button focusRingType="none" translatesAutoresizingMaskIntoConstraints="NO" id="VkG-Lf-5uN">
                         <rect key="frame" x="220" y="37" width="32" height="32"/>
                         <constraints>
                             <constraint firstAttribute="height" constant="32" id="Hiz-6f-8e3"/>
@@ -568,7 +568,7 @@
                             <action selector="forwardAction:" target="494" id="eRO-HX-njM"/>
                         </connections>
                     </button>
-                    <button focusRingType="none" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="AmR-41-4AD">
+                    <button focusRingType="none" translatesAutoresizingMaskIntoConstraints="NO" id="AmR-41-4AD">
                         <rect key="frame" x="104" y="37" width="32" height="32"/>
                         <constraints>
                             <constraint firstAttribute="width" constant="32" id="10T-YX-xLO"/>
@@ -582,7 +582,7 @@
                             <action selector="backAction:" target="494" id="s6P-wr-rlo"/>
                         </connections>
                     </button>
-                    <button focusRingType="none" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="DvI-Lo-u1q">
+                    <button focusRingType="none" translatesAutoresizingMaskIntoConstraints="NO" id="DvI-Lo-u1q">
                         <rect key="frame" x="46" y="37" width="32" height="32"/>
                         <constraints>
                             <constraint firstAttribute="width" constant="32" id="BV3-kr-ePN"/>
@@ -596,7 +596,7 @@
                             <action selector="toggleRepeatMode:" target="494" id="Kl8-wt-uOK"/>
                         </connections>
                     </button>
-                    <button focusRingType="none" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="0Xb-8Y-y5L">
+                    <button focusRingType="none" translatesAutoresizingMaskIntoConstraints="NO" id="0Xb-8Y-y5L">
                         <rect key="frame" x="278" y="37" width="32" height="32"/>
                         <constraints>
                             <constraint firstAttribute="width" constant="32" id="bo5-az-Gwr"/>
@@ -645,7 +645,7 @@
                         </textFieldCell>
                     </textField>
                     <slider focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="8u2-Nn-ZZf">
-                        <rect key="frame" x="18" y="9" width="320" height="20"/>
+                        <rect key="frame" x="18" y="9" width="320" height="21"/>
                         <sliderCell key="cell" refusesFirstResponder="YES" state="on" focusRingType="none" alignment="left" tickMarkPosition="above" sliderType="linear" id="yOD-fm-imH" customClass="PlaybackSliderCell"/>
                         <connections>
                             <action selector="setPlaybackTime:" target="vhZ-72-AYY" id="844-7Z-MTH"/>
@@ -750,7 +750,7 @@
                     </textFieldCell>
                 </textField>
                 <slider verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="dNn-V0-8Tw">
-                    <rect key="frame" x="146" y="6" width="96" height="20"/>
+                    <rect key="frame" x="146" y="6" width="96" height="21"/>
                     <constraints>
                         <constraint firstAttribute="width" constant="92" id="qn0-2S-Sba"/>
                     </constraints>


### PR DESCRIPTION
I was often confused by notifications not showing up when I was controlling the player. I found an old closed issue (#341) in which someone else was caught by this as well. I've added a preference to always show the notifications, even if the app is in focus.