### PR TITLE
Fix for window drag lag and UI freezes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,17 @@ This file should follow the standards specified on [keepachangelog.com](http://k
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
+### Added
+* Option to switch between standard and custom title bar. This is set to standard by default to fix a UI freeze issue in El Capitan - to switch back, go to preferences > appearance > use custom title bar ([#480](https://github.com/radiant-player/radiant-player-mac/pull/480)
+
 ### Changed
 * Updated mini player to use Play Music orange consistently ([#476](https://github.com/radiant-player/radiant-player-mac/pull/476)
 * Always show notifications, even if window is in focus ([#472](https://github.com/radiant-player/radiant-player-mac/pull/472), [@jscheel](https://github.com/jscheel))
 * Various legacy code cleanup / removal ([#465](https://github.com/radiant-player/radiant-player-mac/pull/465))
+
+### Fixed
+* Fixed player randomly freezing after minimizing ([#480](https://github.com/radiant-player/radiant-player-mac/pull/480)
+* Fixed choppiness/lag when dragging the player ([#480](https://github.com/radiant-player/radiant-player-mac/pull/480)
 
 ## [1.6.2] - 2015-12-20
 ### Fixed

--- a/radiant-player-mac/Preferences.plist
+++ b/radiant-player-mac/Preferences.plist
@@ -44,6 +44,8 @@
 	<string>Cocoa</string>
 	<key>styles.enabled</key>
 	<true/>
+	<key>titlebar.enabled</key>
+	<false/>
 	<key>eventtap.alternative-method</key>
 	<false/>
 	<key>cookies.use-safari</key>

--- a/radiant-player-mac/Preferences/PreferencesWindowController.xib
+++ b/radiant-player-mac/Preferences/PreferencesWindowController.xib
@@ -262,21 +262,11 @@
         </customView>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
         <customView id="D7u-3l-nVG" userLabel="Appearance Preferences">
-            <rect key="frame" x="0.0" y="0.0" width="362" height="134"/>
+            <rect key="frame" x="0.0" y="0.0" width="397" height="194"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
             <subviews>
-                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="SCo-65-NqE">
-                    <rect key="frame" x="18" y="52" width="83" height="17"/>
-                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <animations/>
-                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Appearance:" id="q47-FP-1Ro">
-                        <font key="font" metaFont="system"/>
-                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                    </textFieldCell>
-                </textField>
                 <button id="hgY-IX-Stx">
-                    <rect key="frame" x="105" y="50" width="333" height="18"/>
+                    <rect key="frame" x="140" y="48" width="333" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <animations/>
                     <buttonCell key="cell" type="check" title="Use custom application appearance" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="8Ld-sp-HDA">
@@ -288,7 +278,7 @@
                     </connections>
                 </button>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" setsMaxLayoutWidthAtFirstLayout="YES" id="VL8-gZ-dPu">
-                    <rect key="frame" x="18" y="86" width="326" height="28"/>
+                    <rect key="frame" x="53" y="146" width="326" height="28"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <animations/>
                     <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" alignment="center" title="Changing these preferences will require a restart of the application to take effect" id="z4T-NV-tMN">
@@ -298,7 +288,7 @@
                     </textFieldCell>
                 </textField>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="yZz-74-VDm">
-                    <rect key="frame" x="-2" y="22" width="103" height="17"/>
+                    <rect key="frame" x="33" y="22" width="103" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <animations/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Style:" id="IEE-Nf-LIX">
@@ -308,7 +298,7 @@
                     </textFieldCell>
                 </textField>
                 <box verticalHuggingPriority="750" title="Box" boxType="separator" titlePosition="noTitle" id="zhW-EN-10a">
-                    <rect key="frame" x="12" y="75" width="338" height="5"/>
+                    <rect key="frame" x="47" y="135" width="338" height="5"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <animations/>
                     <color key="borderColor" white="0.0" alpha="0.41999999999999998" colorSpace="calibratedWhite"/>
@@ -316,7 +306,7 @@
                     <font key="titleFont" metaFont="system"/>
                 </box>
                 <popUpButton verticalHuggingPriority="750" id="DeQ-rh-16G">
-                    <rect key="frame" x="105" y="17" width="248" height="26"/>
+                    <rect key="frame" x="140" y="17" width="248" height="26"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <animations/>
                     <popUpButtonCell key="cell" type="push" title="Item 1" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" arrowPosition="arrowAtCenter" selectedItem="YVY-Hd-cdu" id="SuW-cx-g3z">
@@ -341,8 +331,43 @@
                         <binding destination="qKJ-ks-0kW" name="selectedValue" keyPath="values.styles.name" previousBinding="bDM-qg-ACl" id="SEB-nv-2Hs"/>
                     </connections>
                 </popUpButton>
+                <button id="Ok3-NF-VQX">
+                    <rect key="frame" x="140" y="110" width="333" height="18"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                    <animations/>
+                    <buttonCell key="cell" type="check" title="Use custom title bar" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="I4Z-Ky-gCL">
+                        <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                        <font key="font" metaFont="system"/>
+                    </buttonCell>
+                    <connections>
+                        <binding destination="qKJ-ks-0kW" name="value" keyPath="values.titlebar.enabled" id="epE-Yf-m4a"/>
+                    </connections>
+                </button>
+                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="SCo-65-NqE">
+                    <rect key="frame" x="53" y="112" width="83" height="17"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                    <animations/>
+                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Appearance:" id="q47-FP-1Ro">
+                        <font key="font" metaFont="system"/>
+                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                    </textFieldCell>
+                </textField>
+                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" setsMaxLayoutWidthAtFirstLayout="YES" id="MZP-Mn-yFA">
+                    <rect key="frame" x="140" y="78" width="314" height="29"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                    <animations/>
+                    <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" id="1ra-uA-vMS">
+                        <font key="font" metaFont="smallSystem"/>
+                        <string key="title">Disable this if you're experiencing any issues 
+with moving the window or the player freezing</string>
+                        <color key="textColor" name="disabledControlTextColor" catalog="System" colorSpace="catalog"/>
+                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                    </textFieldCell>
+                </textField>
             </subviews>
             <animations/>
+            <point key="canvasLocation" x="292.5" y="-7"/>
         </customView>
         <customObject id="Qr1-oe-yDR" customClass="SUUpdater"/>
         <viewController id="l7y-90-Hoh" customClass="GeneralPreferencesViewController">

--- a/radiant-player-mac/Styles/ApplicationStyle.m
+++ b/radiant-player-mac/Styles/ApplicationStyle.m
@@ -93,7 +93,7 @@
 + (void)applyYosemiteVisualEffects:(WebView *)webView window:(NSWindow *)window appearance:(NSString *)appearanceName
 {
     [window setBackgroundColor:[NSColor colorWithSRGBRed:0.945 green:0.945 blue:0.945 alpha:1]];
-    [(AppDelegate *)[NSApp delegate] useTallTitleBar];
+    //[(AppDelegate *)[NSApp delegate] useTallTitleBar];
     
     [webView setDrawsBackground:NO];
     

--- a/radiant-player-mac/Styles/DarkCyanStyle.m
+++ b/radiant-player-mac/Styles/DarkCyanStyle.m
@@ -17,8 +17,9 @@
         [self setName:@"Dark Cyan"];
         [self setAuthor:@"Chris Chrisostomou & Daniel Stuart"];
         [self setDescription:@"A deep black & cyan style."];
-        [self setWindowColor:[NSColor colorWithSRGBRed:0.133f green:0.137f blue:0.149f alpha:1.0f]];
-        [self setTitleColor:[NSColor colorWithDeviceWhite:0.7f alpha:1.0f]];
+        //[self setWindowColor:[NSColor colorWithDeviceRed:(3/255.0f) green:(156/255.0f) blue:(172/255.0f) alpha:1.0]];
+        [self setWindowColor:[NSColor colorWithDeviceRed:(18/255.0f) green:(19/255.0f) blue:(20/255.0f) alpha:1.0]];
+        [self setTitleColor:[NSColor colorWithDeviceWhite:0.2f alpha:1.0f]];
         [self setCss:[ApplicationStyle cssNamed:@"dark-cyan"]];
         [self setJs:[ApplicationStyle jsNamed:@"dark-cyan"]];
     }

--- a/radiant-player-mac/Styles/GoogleStyle.m
+++ b/radiant-player-mac/Styles/GoogleStyle.m
@@ -17,8 +17,8 @@
         [self setName:@"Google"];
         [self setAuthor:@"Google"];
         [self setDescription:@"The default Google style"];
-        [self setWindowColor:[NSColor colorWithSRGBRed:0.898f green:0.898f blue:0.898f alpha:1.0f]];
-        [self setTitleColor:nil];
+        //[self setWindowColor:[NSColor colorWithDeviceRed:(239/255.0f) green:(108/255.0f) blue:(0/255.0f) alpha:1.0]];
+        [self setWindowColor:[NSColor colorWithDeviceRed:(245/255.0f) green:(245/255.0f) blue:(245/255.0f) alpha:1.0]];
         [self setCss:[ApplicationStyle cssNamed:@"google"]];
         [self setJs:[ApplicationStyle jsNamed:@"google"]];
     }

--- a/radiant-player-mac/Styles/RdiantStyle.m
+++ b/radiant-player-mac/Styles/RdiantStyle.m
@@ -17,8 +17,8 @@
         [self setName:@"Rdiant"];
         [self setAuthor:@"Andrew Norell & Carl Schultze"];
         [self setDescription:@"An homage to the late, great streaming service."];
-        [self setWindowColor:[NSColor colorWithSRGBRed:0.133f green:0.137f blue:0.149f alpha:1.0f]];
-        [self setTitleColor:[NSColor colorWithDeviceWhite:0.7f alpha:1.0f]];
+        //[self setWindowColor:[NSColor colorWithDeviceRed:(1/255.0f) green:(143/255.0f) blue:(213/255.0f) alpha:1.0]];
+        [self setWindowColor:[NSColor colorWithDeviceRed:(245/255.0f) green:(245/255.0f) blue:(245/255.0f) alpha:1.0]];
         [self setCss:[ApplicationStyle cssNamed:@"rdiant"]];
         [self setJs:[ApplicationStyle jsNamed:@"rdiant"]];
     }

--- a/radiant-player-mac/Styles/SpotifyBlackStyle.m
+++ b/radiant-player-mac/Styles/SpotifyBlackStyle.m
@@ -17,8 +17,8 @@
         [self setName:@"Black"];
         [self setAuthor:@"Anthony Barone"];
         [self setDescription:@"A deep black style."];
-        [self setWindowColor:[NSColor colorWithSRGBRed:0.133f green:0.137f blue:0.149f alpha:1.0f]];
-        [self setTitleColor:[NSColor colorWithDeviceWhite:0.7f alpha:1.0f]];
+        [self setWindowColor:[NSColor colorWithDeviceRed:(18/255.0f) green:(19/255.0f) blue:(20/255.0f) alpha:1.0]];
+        [self setTitleColor:[NSColor colorWithDeviceWhite:0.2f alpha:1.0f]];
         [self setCss:[ApplicationStyle cssNamed:@"spotify-black"]];
         [self setJs:[ApplicationStyle jsNamed:@"spotify-black"]];
     }

--- a/radiant-player-mac/css/navigation.css
+++ b/radiant-player-mac/css/navigation.css
@@ -17,10 +17,14 @@
 }
 
 #material-one-left.with-nav {
-  min-width: 300px;
+  min-width: 300px; 
 }
 
 #rp-padding-left {
+    min-width: 10px;
+}
+
+.custom-titlebar #rp-padding-left {
     min-width: 77px;
 }
 

--- a/radiant-player-mac/js/navigation.js
+++ b/radiant-player-mac/js/navigation.js
@@ -19,7 +19,14 @@ if (typeof window.GMNavigation === 'undefined') {
     
     var buttonsEnabled = window.GoogleMusicApp.preferenceForKey("navigation.buttons.enabled");
     var keepLinks = window.GoogleMusicApp.preferenceForKey("navigation.buttons.keep-links");
+
+    var customTitlebar = window.GoogleMusicApp.preferenceForKey("titlebar.enabled");
     
+    if (customTitlebar) {
+        buttonsContainer.parentNode.classList.add("custom-titlebar");
+        //navpadding.className = custom-titlebar;
+    }
+
     if (buttonsEnabled)
     {
         // Create back and forward buttons.


### PR DESCRIPTION
This PR fixes the choppy, laggy effect you get when dragging the player around, and the UI freezes after minimising to dock.

Thanks to some great investigative work by @leemm, it's turned out that disabling the titlebar fixes all of these issues. So I've implemented the fix, made some tweaks to the colors and added a preference to toggle custom titlebar on/off.  I've set it to standard by default because the UI freezes are pretty crippling if you don't know how to work around them. And even then the player will act a bit strange until you restart. Switching it back to custom makes it exactly how it was before.

I'll add enough info in the changelog that anyone who actually reads the upgrade popup will know how to reactivate it.

I spent a while debating whether to make the titlebars match the colour of the header, or to use the "page" colour. I opted for the latter because with the colours matching the header the window controls look too high and the text/search box look too low

<img width="793" alt="screenshot 2016-01-07 21 12 37" src="https://cloud.githubusercontent.com/assets/319883/12185608/f0d5cc64-b593-11e5-9c27-e733a0f52ebf.png">

<img width="718" alt="screenshot 2016-01-07 21 13 28" src="https://cloud.githubusercontent.com/assets/319883/12185612/f8f74378-b593-11e5-963e-d6b064662b02.png">

Thoughts? @radiant-player/radiant-player-mac 
