### PR TITLE
Don't hide when the main window is closed

### DIFF
--- a/radiant-player-mac/AppDelegate.m
+++ b/radiant-player-mac/AppDelegate.m
@@ -61,7 +61,6 @@
 - (BOOL)windowShouldClose:(NSNotification *)notification
 {
     [window orderOut:self];
-    [NSApp hide:self];
     return NO;
 }
 


### PR DESCRIPTION
This is one of the first things I noticed when I started using Radiant. I've never seen an OS X app hide itself when you close its main window, and the behavior was pretty surprising! I hope to make more substantial contributions in the future :notes:.