### PR TITLE
Fix selected preferences tab not being remembered

### DIFF
--- a/radiant-player-mac/Preferences/PreferencesWindowController.m
+++ b/radiant-player-mac/Preferences/PreferencesWindowController.m
@@ -25,7 +25,6 @@
     if (self) {
         [[NSBundle mainBundle] loadNibNamed:NSStringFromClass([PreferencesWindowController class]) owner:self topLevelObjects:nil];
         [self loadControllers];
-        [self.window setStyleMask:([self.window styleMask])];
     }
     
     return self;
@@ -39,7 +38,6 @@
     [self addViewController:privacyController];
     [self addViewController:lastFmController];
     [self addViewController:advancedController];
-    [self selectControllerAtIndex:0];
 }
 
 - (void)showWindow:(id)sender


### PR DESCRIPTION
MASPreferences remembers the last tab selected by the user, this patch just stops overriding it. I tested with no saved tab and it correctly picks the first tab, "General".