### PR TITLE
Dark theme loading message colour

### DIFF
--- a/radiant-player-mac/css/spotify-black.css
+++ b/radiant-player-mac/css/spotify-black.css
@@ -35,7 +35,7 @@ body.material,
 }
 
 #loading-progress-message {
-    color: #444;
+    color: #ddd;
     text-align: center;
 }
 


### PR DESCRIPTION
Missed this one yesterday. Just a tiny change to the loading message colour on dark themes to bring it in line with the header colours
