### PR TITLE
Custom theme fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This file should follow the standards specified on [keepachangelog.com](http://k
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
+* More custom theme styling fixes as a result of Google's latest update ([#515](https://github.com/radiant-player/radiant-player-mac/pull/515))
 
 ## [1.7.2] - 2016-03-07
 * Custom CSS fixes for Google's latest update ([#509](https://github.com/radiant-player/radiant-player-mac/pull/509))

--- a/radiant-player-mac/css/dark-cyan.css
+++ b/radiant-player-mac/css/dark-cyan.css
@@ -37,6 +37,7 @@ paper-slider#sliderBar paper-ripple.paper-slider,
     color: #039cac!important;
 }
 
+explicit,
 .music-source-list::-webkit-scrollbar-thumb,
 sj-paper-button.material-primary, paper-button.material-primary,
 button.primary,
@@ -51,7 +52,9 @@ paper-slider#material-player-progress #sliderContainer.disabled #sliderBar #acti
 paper-progress.paper-slider #primaryProgress.paper-progress,
 .material-drag .song-drag-label,
 .material-transfer-radial-upload-overlay, .material-transfer-radial-download-overlay, .material-transfer-radial-processing-overlay,
-#current-loading-progress {
+#current-loading-progress,
+paper-toggle-button[checked]:not([disabled]) .toggle-button.paper-toggle-button,
+paper-toggle-button[checked]:not([disabled]) .toggle-bar.paper-toggle-button {
     background-color: #039cac!important;
 }
 

--- a/radiant-player-mac/css/rdiant.css
+++ b/radiant-player-mac/css/rdiant.css
@@ -121,7 +121,10 @@ border-color: #018fd5!important;
 background: #018fd5!important;
 }
 
-paper-header-panel#content-container.transparent #material-app-bar {
+paper-header-panel#content-container.transparent #material-app-bar,
+.explicit,
+paper-toggle-button[checked]:not([disabled]) .toggle-button.paper-toggle-button,
+paper-toggle-button[checked]:not([disabled]) .toggle-bar.paper-toggle-button {
 background-color: rgba(1, 143, 213, 0.4)!important;
 }
 

--- a/radiant-player-mac/css/spotify-black.css
+++ b/radiant-player-mac/css/spotify-black.css
@@ -17,8 +17,31 @@ body.material,
     color: #bbb;
 }
 
-#material-app-bar {
-    color: white;
+#material-app-bar,
+paper-button#unsubscribe-playlist-button .playlist-subscribed,
+paper-button#unsubscribe-playlist-button:hover .playlist-unsubscribe {
+    color: white!important;
+}
+
+paper-button#unsubscribe-playlist-button iron-icon[icon="sj:unsubscribe"] path:last-child
+{
+    fill: white;
+}
+
+paper-button#unsubscribe-playlist-button iron-icon[icon="sj:subscribed"] path
+{
+    fill: white;
+}
+
+paper-button#unsubscribe-playlist-button iron-icon[icon="sj:subscribed"] path:last-child
+{
+    stroke: white;
+}
+
+paper-button#unsubscribe-playlist-button iron-icon[icon="sj:subscribed"] path:first-child,
+paper-button#unsubscribe-playlist-button iron-icon[icon="sj:subscribed"] path:last-child
+{
+    fill: transparent;
 }
 
 .material .cluster-text-protection,


### PR DESCRIPTION
Replacement for #514 (whoops)

Few styling tweaks for the custom themes. Explicit warning icons, playlist subscription icons & text, slider buttons on the settings pages. Applied to dark-cyan and Rdiant where applicable.

Not sure how many of these are new from Google's recent update, and how many are lingering issues that haven't been noticed before now.