### PR TITLE
Background colour to highlight play button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ This file should follow the standards specified on [keepachangelog.com](http://k
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
-* More custom theme styling fixes as a result of Google's latest update ([#515](https://github.com/radiant-player/radiant-player-mac/pull/515))
+* More custom theme styling fixes ([#515](https://github.com/radiant-player/radiant-player-mac/pull/515), [#516](https://github.com/radiant-player/radiant-player-mac/pull/516))
 
 ## [1.7.2] - 2016-03-07
 * Custom CSS fixes for Google's latest update ([#509](https://github.com/radiant-player/radiant-player-mac/pull/509))

--- a/radiant-player-mac/css/spotify-black.css
+++ b/radiant-player-mac/css/spotify-black.css
@@ -267,6 +267,7 @@ a, .simple-dialog a {
 
 .hover-button[data-id="play"], .material .song-row .rating-container.thumbs [data-rating] {
     cursor:pointer;
+    color:white;
 }
 
 .music-banner {
@@ -546,15 +547,14 @@ div.simple-dialog-bg {
     color: white;
 }
 
-[data-account-type="all-access"] .actions sj-paper-button[data-id="radio"] .icon,
-.header-row [data-col="duration"] .icon,
-.header-row [data-col="play-count"] .icon,
-.material .song-row .rating-container.thumbs [data-rating],
-.material .song-row .rating-container.thumbs [data-rating],
-.material .song-row [data-col="index"] .hover-button[data-id=play],
-.material .song-row [data-col="track"] .hover-button[data-id=play]
-{
-    background-image: url(https://radiant-player-mac/sprites-inverted.png) !important;
+.material .song-row [data-col="index"] .hover-button[data-id="play"],
+.material .song-row [data-col="track"] .hover-button[data-id="play"] {
+    border-radius:30px;
+    background-color:#d3d3d3;
+}
+
+.material .song-row .rating-container.thumbs [data-rating] {
+    -webkit-filter:invert(100%);
 }
 
 .material .song-row .column-content {


### PR DESCRIPTION
It seems as though the inverted sprites have stopped working.  I took a look and couldn't puzzle out what was going wrong.

So I started looking at where we were actually using these sprites - it seems that we were generating an entire inverted spritesheet for 4 icons (plus 3 selectors that were no longer in use).

Using the filter:invert css rule I've managed to invert the colour of 2 of them, allowing it to use the original spritesheet (props to @MarshallOfSound)

The play button though wasn't so easy, as inverted it also inverted the background, turning it from dark grey to light grey on lighter grey.  Elsewhere around the site they've converted the buttons to use SVGs, so this single button is a bit of a weird exception.

So, in lieu of what is essentially generating an entire spritesheet for a single icon, I've applied some CSS styling to make it look more like the play buttons around the site - circular with the play button in the middle, using the original spritesheet.  This fixes the styling issue, and pretty much makes the inverted stylesheet generator redundant.
