### PR TITLE
gpm update tweaks; rdiant theme styling bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This file should follow the standards specified on [keepachangelog.com](http://k
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
+### Fixed
+* Styling fixes for Google's latest update ([#543](https://github.com/radiant-player/radiant-player-mac/pull/543))
 
 ## [1.8.2] - 2016-04-04
 ### Fixed

--- a/radiant-player-mac/Popup/PlaybackSliderCell.m
+++ b/radiant-player-mac/Popup/PlaybackSliderCell.m
@@ -133,8 +133,8 @@
 
 - (NSColor *)accentColor
 {
-    // Play music orange RGB: 237/108/31
-    return [NSColor colorWithDeviceRed:(237/255.0f) green:(108/255.0f) blue:(31/255.0f) alpha:1.0];
+    // Play music orange RGB: 255/76/29
+    return [NSColor colorWithDeviceRed:(255/255.0f) green:(76/255.0f) blue:(29/255.0f) alpha:1.0];
 }
 
 @end

--- a/radiant-player-mac/css/dark-cyan.css
+++ b/radiant-player-mac/css/dark-cyan.css
@@ -37,7 +37,7 @@ paper-slider#sliderBar paper-ripple.paper-slider,
     color: #039cac!important;
 }
 
-explicit,
+.explicit,
 .music-source-list::-webkit-scrollbar-thumb,
 sj-paper-button.material-primary, paper-button.material-primary,
 button.primary,
@@ -49,7 +49,7 @@ paper-checkbox #checkbox.checked,
 paper-slider #sliderBar #activeProgress,
 paper-slider#material-player-progress #sliderContainer.disabled #sliderBar #activeProgress,
 #sliderKnobInner.paper-slider,
-paper-progress.paper-slider #primaryProgress.paper-progress,
+#primaryProgress.paper-progress,
 .material-drag .song-drag-label,
 .material-transfer-radial-upload-overlay, .material-transfer-radial-download-overlay, .material-transfer-radial-processing-overlay,
 #current-loading-progress,

--- a/radiant-player-mac/css/rdiant.css
+++ b/radiant-player-mac/css/rdiant.css
@@ -100,7 +100,7 @@ paper-checkbox #checkbox.checked,
 paper-slider #sliderBar #activeProgress,
 paper-slider#material-player-progress #sliderContainer.disabled #sliderBar #activeProgress,
 #sliderKnobInner.paper-slider,
-paper-progress.paper-slider #primaryProgress.paper-progress,
+#primaryProgress.paper-progress,
 .material-drag .song-drag-label,
 .material-transfer-radial-upload-overlay, .material-transfer-radial-download-overlay, .material-transfer-radial-processing-overlay,
 #current-loading-progress {


### PR DESCRIPTION
GPM update

- Small tweak to the loading slider selector to make less specific. 
- Slight change to the Google Music Orange (need to look into how we're doing this - the colour rendered isn't exactly the colour specified, though you'd only notice by comparing in photoshop. Mostly a nitpick)
- Fixed a styling bug in the Rdiant theme

Relatively pain free this time :smile:
