### PR TITLE
Fix/explicit color

### DIFF
--- a/radiant-player-mac/css/dark-cyan.css
+++ b/radiant-player-mac/css/dark-cyan.css
@@ -7,6 +7,7 @@
  *
  */
 
+iron-icon[icon="av:explicit"],
 music-content .info-card sj-paper-button, #music-content .info-card paper-button,
 .top-charts-view .song-row [data-col="index"] .column-content, .material-card .details .left-items .index,
 .more-songs-container,
@@ -37,7 +38,6 @@ paper-slider#sliderBar paper-ripple.paper-slider,
     color: #039cac!important;
 }
 
-.explicit,
 .music-source-list::-webkit-scrollbar-thumb,
 sj-paper-button.material-primary, paper-button.material-primary,
 button.primary,

--- a/radiant-player-mac/css/rdiant.css
+++ b/radiant-player-mac/css/rdiant.css
@@ -59,6 +59,7 @@ box-shadow: 0 0 5px 0 rgba(0, 0, 0, 0.07);
 -o-box-shadow: 0 0 5px 0 rgba(0, 0, 0, 0.07);
 }
 
+iron-icon[icon="av:explicit"],
 music-content .info-card sj-paper-button, #music-content .info-card paper-button,
 .top-charts-view .song-row [data-col="index"] .column-content, .material-card .details .left-items .index,
 .more-songs-container,
@@ -122,7 +123,6 @@ background: #018fd5!important;
 }
 
 paper-header-panel#content-container.transparent #material-app-bar,
-.explicit,
 paper-toggle-button[checked]:not([disabled]) .toggle-button.paper-toggle-button,
 paper-toggle-button[checked]:not([disabled]) .toggle-bar.paper-toggle-button {
 background-color: rgba(1, 143, 213, 0.4)!important;

--- a/radiant-player-mac/css/yosemite.css
+++ b/radiant-player-mac/css/yosemite.css
@@ -126,7 +126,7 @@ body {
     margin-top: 1px;
 }
 
-.song-row .explicit {
+.song-row iron-icon[icon="av:explicit"] {
     margin-top: 8px;
 }
 


### PR DESCRIPTION
Fixes the explicit icon colour on custom themes, after what looks like a change at Google's end

Before:
![screenshot 2016-07-21 14 51 52](https://cloud.githubusercontent.com/assets/319883/17025226/e7977586-4f52-11e6-9c65-ecf8304e7cba.png)

After:
![screenshot 2016-07-21 14 51 19](https://cloud.githubusercontent.com/assets/319883/17025233/edbc4ee6-4f52-11e6-8268-1b2bcdc08d19.png)
