### PR TITLE
Scope our script insertion in an IIFE

### DIFF
--- a/radiant-player-mac/AppDelegate.m
+++ b/radiant-player-mac/AppDelegate.m
@@ -1003,12 +1003,12 @@ static CGEventRef event_tap_callback(CGEventTapProxy proxy,
 - (void) evaluateJavaScriptFile:(NSString *)name
 {
     NSString *template =
-        @"if (document.querySelector('#rp-script-%1$@') == null) {"
+        @"(function() { if (document.querySelector('#rp-script-%1$@') == null) {"
         "    var js = document.createElement('script');"
         "    js.id = 'rp-script-%1$@';"
         "    js.src = 'https://radiant-player-mac/js/%1$@.js';"
         "    document.head.appendChild(js);"
-        "}";
+        "}})();";
     NSString *insert = [NSString stringWithFormat:template, name];
     [webView stringByEvaluatingJavaScriptFromString:insert];
 }


### PR DESCRIPTION
Google's uglifier just named a global variable `js`, which happens to conflict with our previous script injection script (which unintentionally created a global variable also named `js`).

This PR wraps our script injection in an IIFE and no longer pollutes the global namespace.

Fixes #572 

/cc @radiant-player/radiant-player-mac 