### PR TITLE
Patch missing function causing blank screen

### DIFF
--- a/radiant-player-mac/AppDelegate.m
+++ b/radiant-player-mac/AppDelegate.m
@@ -877,6 +877,7 @@ static CGEventRef event_tap_callback(CGEventTapProxy proxy,
 - (void)webView:(WebView *)webView didClearWindowObject:(WebScriptObject *)windowObject forFrame:(WebFrame *)frame
 {
     [windowObject setValue:self forKey:@"GoogleMusicApp"];
+    [windowObject evaluateWebScript:@"window.performance.getEntriesByType = window.performance.getEntriesByType || function() { return []; };"];
 }
 
 - (void)webView:(WebView *)sender didFailLoadWithError:(NSError *)error forFrame:(WebFrame *)frame
@@ -907,6 +908,7 @@ static CGEventRef event_tap_callback(CGEventTapProxy proxy,
 
 - (void)webView:(WebView *)sender didCommitLoadForFrame:(WebFrame *)frame
 {
+    [sender stringByEvaluatingJavaScriptFromString:@"window.performance.getEntriesByType = window.performance.getEntriesByType || function() { return []; };"];
     NSString *url = [[[[frame dataSource] request] URL] absoluteString];
 
     if ([url isEqualToString:@"https://play.google.com/music/listen"]) {


### PR DESCRIPTION
On startup, the error `TypeError: window.performance.getEntriesByType is not a function` gets thrown. This is an issue with Safari not having that function. <a href="https://developer.mozilla.org/en-US/docs/Web/API/Performance/getEntriesByType">From MDN</a> it looks like it's just for measuring performance, which isn't essential to the operation of the program, so I replaced it with a function returning an empty array so that everything else can continue running.

This should fix https://github.com/radiant-player/radiant-player-mac/issues/575 and https://github.com/radiant-player/radiant-player-mac/issues/577.

Here's a .zip of the app to test with, to verify if it works for you:
[Radiant Player-fix.zip](https://github.com/radiant-player/radiant-player-mac/files/398434/Radiant.Player-fix.zip)
