### PR TITLE
Add "Feeling Lucky" to Menu

### DIFF
--- a/radiant-player-mac/en.lproj/MainMenu.xib
+++ b/radiant-player-mac/en.lproj/MainMenu.xib
@@ -172,6 +172,12 @@
                                     <action selector="forwardAction:" target="494" id="PeZ-B7-4Lc"/>
                                 </connections>
                             </menuItem>
+                            <menuItem title="I’m Feeling Lucky!" keyEquivalent="l" id="we1-8F-Jwk">
+                                <modifierMask key="keyEquivalentModifierMask" command="YES"/>
+                                <connections>
+                                    <action selector="luckyAction:" target="494" id="Qce-mS-jlr"/>
+                                </connections>
+                            </menuItem>
                             <menuItem isSeparatorItem="YES" id="UoN-kB-9nv"/>
                             <menuItem title="Volume" id="ylU-oy-rjV">
                                 <modifierMask key="keyEquivalentModifierMask"/>


### PR DESCRIPTION
As requested in #346. Note that even though this is just a few lines, someone should review them, because I know nothing about Mac OS development. It does work for me.

Though this does raise the question whether the "I’m feeling lucky" button should be present in the main window too, rather than just in the mini-player.