### PR TITLE
macOS Sierra Fixes w/ MiniPlayer and CSS Updates

### DIFF
--- a/radiant-player-mac/AppDelegate.h
+++ b/radiant-player-mac/AppDelegate.h
@@ -139,6 +139,7 @@
 - (void) ratingChanged:(NSInteger)rating;
 
 - (id) preferenceForKey:(NSString *)key;
+- (BOOL) isSierra;
 - (BOOL) isElCapitan;
 - (BOOL) isYosemite;
 - (BOOL) isMavericks;

--- a/radiant-player-mac/AppDelegate.m
+++ b/radiant-player-mac/AppDelegate.m
@@ -1004,6 +1004,11 @@ static CGEventRef event_tap_callback(CGEventTapProxy proxy,
         return nil;
 }
 
+- (BOOL)isSierra
+{
+    return floor(NSAppKitVersionNumber) >= 1485;
+}
+
 - (BOOL)isElCapitan
 {
     return floor(NSAppKitVersionNumber) > NSAppKitVersionNumber10_10_Max;

--- a/radiant-player-mac/Popup/PopupView.m
+++ b/radiant-player-mac/Popup/PopupView.m
@@ -181,16 +181,28 @@
 
 - (void)updateTrackingAreas
 {
+    
     if (trackingArea != nil) {
-        [self removeTrackingArea:trackingArea];
+        if(!delegate.appDelegate.isSierra) {
+            [self removeTrackingArea:trackingArea];
+        }
     }
-
-    int opts = (NSTrackingMouseEnteredAndExited | NSTrackingActiveAlways);
-    trackingArea = [ [NSTrackingArea alloc] initWithRect:[self bounds]
-                                                 options:opts
-                                                   owner:self
-                                                userInfo:nil];
-    [self addTrackingArea:trackingArea];
+    
+    if(!delegate.appDelegate.isSierra) {
+        int opts = (NSTrackingMouseEnteredAndExited | NSTrackingActiveAlways);
+        trackingArea = [ [NSTrackingArea alloc] initWithRect:[self bounds]
+                                                     options:opts
+                                                       owner:self
+                                                    userInfo:nil];
+        [self addTrackingArea:trackingArea];
+    } else {
+        NSTrackingArea* trackingArea = [[NSTrackingArea alloc]
+                                        initWithRect:[self bounds]
+                                        options: (NSTrackingMouseEnteredAndExited |  NSTrackingActiveAlways)
+                                        owner:self
+                                        userInfo:nil];
+        [self addTrackingArea:trackingArea];
+    }
 }
 
 - (void)setHoverAlphaMultiplier:(CGFloat)hoverAlphaMultiplier

--- a/radiant-player-mac/Styles/DarkCyanStyle.m
+++ b/radiant-player-mac/Styles/DarkCyanStyle.m
@@ -28,7 +28,7 @@
 
 - (void)applyToWebView:(WebView *)webView window:(NSWindow *)window
 {
-    [self setCss:[NSString stringWithFormat:@"%@%@", [self css], [ApplicationStyle cssNamed:@"spotify-black"]]];
+    [self setCss:[NSString stringWithFormat:@"%@%@", [ApplicationStyle cssNamed:@"spotify-black"] , [self css]]];
     [super applyToWebView:webView window:window];
 }
 

--- a/radiant-player-mac/WebView/CookieStorage.h
+++ b/radiant-player-mac/WebView/CookieStorage.h
@@ -36,6 +36,8 @@
 - (void)unarchive;
 - (void)clearCookies;
 
+- (BOOL) isSierra;
+
 + (NSString *)defaultCookieStoragePath;
 
 @end

--- a/radiant-player-mac/WebView/CookieStorage.m
+++ b/radiant-player-mac/WebView/CookieStorage.m
@@ -213,6 +213,11 @@
 
 #pragma mark - Miscellaneous
 
+- (BOOL)isSierra
+{
+    return floor(NSAppKitVersionNumber) >= 1485;
+}
+
 + (BOOL)hostMatchesDomainWithURL:(NSURL *)url domain:(NSString *)domain
 {
     // The domain must either match the host exactly, or it must

--- a/radiant-player-mac/WebView/CustomWebView.m
+++ b/radiant-player-mac/WebView/CustomWebView.m
@@ -179,7 +179,10 @@
         [[CookieStorage instance] handleCookiesInResponse:(NSHTTPURLResponse *)redirectResponse];
     }
     
-    [request setHTTPShouldHandleCookies:NO];
+    if(![[CookieStorage instance] isSierra]){
+        [request setHTTPShouldHandleCookies:NO];
+    }
+    
     [[CookieStorage instance] handleCookiesInRequest:request];
 }
 

--- a/radiant-player-mac/css/dark-cyan.css
+++ b/radiant-player-mac/css/dark-cyan.css
@@ -77,3 +77,31 @@ paper-action-dialog.get-link .content paper-spinner .circle,
 paper-header-panel#content-container.transparent #material-app-bar {
     background-color: rgba(3, 166, 181, 0.4)!important;
 }
+
+/* New drawer / other additions */
+[class*="sj-play-button"] #pulse {
+    background-color: rgba(3, 156, 172, 0.4)!important;
+}
+
+[class*="sj-play-button"] #buttonContent {
+    background: #039cac!important;
+}
+
+.primary:not([style-scope]):not(.style-scope) {
+    color: #039cac!important;
+}
+
+paper-dialog input::selection,
+paper-dialog textarea::selection {
+    background-color: rgba(3, 156, 172, 0.25) !important
+}
+
+.label-is-highlighted [id*="paper-input-label"],
+[class*="paper-input-container"] .add-on-content.is-highlighted.paper-input-container * {
+    color: #039cac!important;
+}
+
+.ups,
+.focused-line {
+    background: #039cac!important;
+}

--- a/radiant-player-mac/css/google.css
+++ b/radiant-player-mac/css/google.css
@@ -15,11 +15,13 @@
 
 /* Fill to highlight thumbed up/down track in status bar */
 paper-icon-button[aria-label="Undo thumb-up"] iron-icon {
-    background: url('https://radiant-player-mac/images/sprites.png') no-repeat -276px -235px;
-    background-size: 763px 360px;
+    /*background: url('https://radiant-player-mac/images/sprites.png') no-repeat -265px -222px;
+     background-size: 725px 335px;*/
+    display: inline-block;
 }
 
 paper-icon-button[aria-label="Undo thumb-down"] iron-icon {
-    background: url('https://radiant-player-mac/images/sprites.png') no-repeat -165px -323px;
-    background-size: 763px 360px;
+    /*background: url('https://radiant-player-mac/images/sprites.png') no-repeat -165px -333px;
+     background-size: 753px 368px;*/
+    display: inline-block;
 }

--- a/radiant-player-mac/css/rdiant.css
+++ b/radiant-player-mac/css/rdiant.css
@@ -14,7 +14,7 @@ textarea, .top-charts-view .song-row [data-col="index"] .column-content,
 .material-card .details .left-items .index, .button,
 .simple-dialog-buttons button, .download-submit, .goog-menuheader, .now-playing-menu .goog-menuitem .goog-menuitem-content,
 .goog-menuitem-content, #loading-progress-message, .screensaver .collage .text.time, .visualizercard .label, .bar-button .text {
-	font-family: 'Whitney', 'Open Sans', Helvetica, arial, sans-serif;
+    font-family: 'Whitney', 'Open Sans', Helvetica, arial, sans-serif;
 }
 .cluster .header .title, .cluster .header .subtitle,
 .material-detail-view .material-container-details .info .title,
@@ -47,16 +47,16 @@ paper-button, .material .recommended-header,
 #time_container_current, #time_container_duration,
 #mini-queue-details .playing-from-title, #mini-queue-details .playing-from .album, #mini-queue-details .playing-from
 {
-font-weight: 300;
+    font-weight: 300;
 }
 body.material {
-background-color:#FFF;
+    background-color:#FFF;
 }
 #material-app-bar {
-box-shadow: 0 0 5px 0 rgba(0, 0, 0, 0.07);
--webkit-box-shadow: 0 0 5px 0 rgba(0, 0, 0, 0.07);
--moz-box-shadow: 0 0 5px 0 rgba(0, 0, 0, 0.07);
--o-box-shadow: 0 0 5px 0 rgba(0, 0, 0, 0.07);
+    box-shadow: 0 0 5px 0 rgba(0, 0, 0, 0.07);
+    -webkit-box-shadow: 0 0 5px 0 rgba(0, 0, 0, 0.07);
+    -moz-box-shadow: 0 0 5px 0 rgba(0, 0, 0, 0.07);
+    -o-box-shadow: 0 0 5px 0 rgba(0, 0, 0, 0.07);
 }
 
 iron-icon[icon="av:explicit"],
@@ -87,7 +87,7 @@ paper-action-dialog sj-paper-button, paper-dialog .buttons paper-button,
 paper-slider#sliderBar paper-ripple.paper-slider,
 .material .song-table .song-row.currently-playing td
 {
-color: #018fd5!important;
+    color: #018fd5!important;
 }
 
 .music-source-list::-webkit-scrollbar-thumb,
@@ -105,7 +105,7 @@ paper-slider#material-player-progress #sliderContainer.disabled #sliderBar #acti
 .material-drag .song-drag-label,
 .material-transfer-radial-upload-overlay, .material-transfer-radial-download-overlay, .material-transfer-radial-processing-overlay,
 #current-loading-progress {
-	background-color: #018fd5!important;
+    background-color: #018fd5!important;
 }
 
 paper-checkbox #checkbox.checked,
@@ -116,26 +116,77 @@ paper-action-dialog.get-link .content paper-spinner .circle,
 .nav-section .selected,
 #sliderKnobInner.paper-slider
 {
-	border-color: #018fd5!important;
+    border-color: #018fd5!important;
 }
 
 .material-container-details sj-fab, .material-container-details paper-fab {
-background: #018fd5!important;
+    background: #018fd5!important;
 }
 
 paper-header-panel#content-container.transparent #material-app-bar,
 paper-toggle-button[checked]:not([disabled]) .toggle-button.paper-toggle-button,
 paper-toggle-button[checked]:not([disabled]) .toggle-bar.paper-toggle-button {
-background-color: rgba(1, 143, 213, 0.4)!important;
+    background-color: rgba(1, 143, 213, 0.4)!important;
 }
 
 /* Fill to highlight thumbed up/down track in status bar */
 paper-icon-button[aria-label="Undo thumb-up"] iron-icon {
-    background: url('https://radiant-player-mac/images/sprites.png') no-repeat -276px -235px;
-    background-size: 763px 360px;
+    /*background: url('https://radiant-player-mac/images/sprites.png') no-repeat -265px -222px;
+     background-size: 725px 335px;*/
+    display: inline-block;
 }
 
 paper-icon-button[aria-label="Undo thumb-down"] iron-icon {
-    background: url('https://radiant-player-mac/images/sprites.png') no-repeat -165px -323px;
-    background-size: 763px 360px;
+    /*background: url('https://radiant-player-mac/images/sprites.png') no-repeat -165px -333px;
+     background-size: 753px 368px;*/
+    display: inline-block;
+}
+
+
+/* New drawer / other additions */
+[class*="sj-play-button"] #pulse {
+    background-color: rgba(1, 143, 213, 0.4)!important;
+}
+
+[class*="sj-play-button"] #buttonContent {
+    background: #018fd5!important;
+}
+.primary:not([style-scope]):not(.style-scope) {
+    color: #018fd5!important;
+}
+
+paper-dialog input::selection,
+paper-dialog textarea::selection {
+    background-color: rgba(1, 143, 213, 0.25) !important
+}
+
+.label-is-highlighted [id*="paper-input-label"],
+[class*="paper-input-container"] .add-on-content.is-highlighted.paper-input-container * {
+    color: #018fd5!important;
+}
+
+.ups,
+.focused-line {
+    background: #018fd5!important;
+}
+
+.ups.light {
+    background: transparent!important;
+}
+
+.ups paper-button,
+.ad-preroll-message-link paper-button,
+paper-button.nav-item-container.sub {
+    background-color: #0170a7!important;
+}
+
+.ups paper-button:focus,
+.ad-preroll-message-link paper-button:focus,
+paper-button.nav-item-container.sub:focus {
+    background-color: #018fd5!important;
+    border: 1px solid #0170a7!important
+}
+
+.share-buttons .share-button iron-icon {
+    z-index: 0 !important;
 }

--- a/radiant-player-mac/css/spotify-black.css
+++ b/radiant-player-mac/css/spotify-black.css
@@ -77,7 +77,7 @@ a, .simple-dialog a {
 }
 
 .card-group {
-	height: 520px !important;
+    height: 520px !important;
 }
 
 .material-card,
@@ -95,7 +95,7 @@ a, .simple-dialog a {
 }
 
 .material-card .reason {
-	border-top-color: transparent;
+    border-top-color: transparent;
 }
 
 .material-card.entity-card, .material-card.entity-card .details {
@@ -141,9 +141,9 @@ a, .simple-dialog a {
     border-color: transparent transparent rgba(18, 19, 20, 0.98) rgba(18, 19, 20, 0.98);
 }
 
-.material-album-container.material-container, 
-.material-detail-view .artist-details, 
-.material-container-details, 
+.material-album-container.material-container,
+.material-detail-view .artist-details,
+.material-container-details,
 .material-container-details .info {
     background-color: rgba(18, 19, 20, 0.8)!important;
     color: white;
@@ -177,8 +177,8 @@ a, .simple-dialog a {
 
 .material .song-row.hover .song-indicator,
 .material .song-row.selected-song-row .song-indicator {
-	/*background-color: #222326 !important;
-    -webkit-filter: none;*/
+    /*background-color: #222326 !important;
+     -webkit-filter: none;*/
 }
 
 .material .song-row td {
@@ -283,7 +283,7 @@ a, .simple-dialog a {
     border-color: #222 !important;
 }
 
-#nav, #nav-container, .material .nav-toolbar {
+#nav, #nav-container, .material .nav-toolbar{
     background-color: #222326 !important;
     border-right: 1px solid #292929;
 }
@@ -385,8 +385,17 @@ a, .simple-dialog a {
     background: #121314;
 }
 
+.material-card .details {
+    padding: 16px;
+    position: relative;
+}
+
 .fade-out:after {
-    background: none !important;
+    background: linear-gradient(to right,rgba(34, 35, 38,0),rgba(34, 35, 38,1))!important;
+}
+
+.material-card .details paper-icon-button.menu-anchor {
+    color: #fff !important
 }
 
 #player, .player-middle {
@@ -485,13 +494,13 @@ div.simple-dialog-bg {
 }
 
 @-webkit-keyframes slidedown {
-   from {
-      max-height: 0%;
-   }
-
-   to {
-      max-height: 100%;
-   }
+    from {
+        max-height: 0%;
+    }
+    
+    to {
+        max-height: 100%;
+    }
 }
 
 .simple-dialog-title, .simple-dialog-content {
@@ -550,7 +559,7 @@ div.simple-dialog-bg {
 .material .song-row [data-col="index"] .hover-button[data-id="play"],
 .material .song-row [data-col="track"] .hover-button[data-id="play"] {
     /*border-radius:30px;
-    background-color:#d3d3d3;*/
+     background-color:#d3d3d3;*/
     background-image: url(https://radiant-player-mac/sprites-inverted.png) !important;
 }
 
@@ -559,7 +568,7 @@ div.simple-dialog-bg {
 }
 
 .material .song-row .column-content {
-  background-color: transparent !important;
+    background-color: transparent !important;
 }
 
 .material .song-row:hover,
@@ -586,22 +595,146 @@ div.simple-dialog-bg {
 
 /* Fill to highlight thumbed up/down track in status bar */
 paper-icon-button[aria-label="Undo thumb-up"] iron-icon {
-    background: url('https://radiant-player-mac/images/sprites.png') no-repeat -310px -315px;
-    background-size: 763px 360px;
+    /*background: url('https://radiant-player-mac/images/sprites.png') no-repeat -265px -222px;
+     background-size: 725px 335px;*/
+    display: inline-block;
 }
 
 paper-icon-button[aria-label="Undo thumb-down"] iron-icon {
-    background: url('https://radiant-player-mac/images/sprites.png') no-repeat -344px -209px;
-    background-size: 763px 360px;
+    /*background: url('https://radiant-player-mac/images/sprites.png') no-repeat -165px -333px;
+     background-size: 753px 368px;*/
+    display: inline-block;
 }
+
 
 /* Hidden SVG & replaced icon */
 /*
-paper-icon-button[aria-label="Undo thumb-up"] iron-icon {
-    background: url('https://radiant-player-mac/sprites-inverted.png') no-repeat -334px -348px;
-    background-size: 820px 395px;
+ paper-icon-button[aria-label="Undo thumb-up"] iron-icon {
+ background: url('https://radiant-player-mac/sprites-inverted.png') no-repeat -334px -348px;
+ background-size: 820px 395px;
+ }
+ paper-icon-button[aria-label="Thumb-up"] iron-icon svg {
+ display: none!important;
+ }
+ */
+
+/* New drawer / other additions */
+[class*="sj-play-button"] #pulse {
+    background-color: rgba(255, 87, 34, 0.4)!important;
 }
-paper-icon-button[aria-label="Thumb-up"] iron-icon svg {
-    display: none!important;
+
+[class*="sj-play-button"] #buttonContent {
+    background: #ff5722!important;
 }
-*/
+
+.primary:not([style-scope]):not(.style-scope) {
+    color: #ff5722!important;
+}
+
+#music-content .info-card,
+#playlist-drawer .sj-right-drawer,
+#playlist-drawer .sj-right-drawer #topBar {
+    background: #222326 !important;
+}
+
+
+#music-content .info-card * {
+    color: rgb(193, 193, 193) !important
+}
+
+.share-buttons .button-label,
+#checkboxLabel,
+#playlist-drawer .sj-right-drawer #topBar {
+    color: white !important
+}
+
+.column .material-card[data-size="small"][data-type="imfl"] .title {
+    color: #c2c2c2 !important;
+}
+
+[class*="paper-dialog"] {
+    color: white !important;
+    background: #222326 !important;
+}
+
+[class*="paper-dialog"] [class*="paper-input-container"] .input-content.paper-input-container input,
+[class*="paper-dialog"] [class*="paper-input-container"] .input-content.paper-input-container textarea,
+[class*="paper-dialog"] [class*="paper-input-container"] .input-content:not(.label-is-highlighted).paper-input-container label,
+[class*="paper-dialog"] [class*="paper-input-container"] .input-content:not(.label-is-highlighted).paper-input-container .paper-input-label
+[class*="paper-dialog"] [class*="paper-input-container"] .input-content.paper-input-container iron-autogrow-textarea,
+[class*="paper-dialog"] [class*="paper-input-container"] .input-content.paper-input-container .paper-input-input {
+    color: white !important
+}
+
+#playlist-drawer .sj-right-drawer #dropShadow {
+    display: none;
+}
+
+paper-dialog input::selection,
+paper-dialog textarea::selection {
+    background-color: rgba(255, 87, 34, 0.25) !important
+}
+
+[class*="paper-button"][disabled],
+[class*="paper-dialog-scrollable"].is-scrolled:not(:first-child)::before,
+paper-dialog-scrollable.can-scroll:not([style-scope]):not(.style-scope):not(.scrolled-to-bottom)::after {
+    background-color: #333439 !important
+}
+
+.share-buttons,
+gpm-action-buttons,
+.my-devices-card .device-list-item:not(:last-child),
+.labs-card .lab-list-item:not(:last-child),
+#playlist-drawer .autoplaylist-section, #playlist-drawer #recent-playlists-container,
+#playlist-drawer paper-header-panel[at-top] paper-toolbar:not([style-scope]):not(.style-scope) {
+    border-color: #333439 !important
+}
+
+#playlist-drawer .playlist-drawer-item .playlist-wrapper:hover,
+#playlist-drawer .playlist-drawer-item .playlist-wrapper:focus,
+#playlist-drawer .playlist-drawer-item sj-play-button:hover~.playlist-wrapper,
+#playlist-drawer .playlist-drawer-item iron-icon:hover~.playlist-wrapper,
+#playlist-drawer .playlist-drawer-item.playlist-drop-target:not(.subscribed) .playlist-wrapper {
+    background-color: #2E2F33 !important;
+    color: white !important
+}
+
+
+.label-is-highlighted [id*="paper-input-label"],
+[class*="paper-input-container"] .add-on-content.is-highlighted.paper-input-container * {
+    color: #ff5722!important;
+}
+
+.ups,
+.focused-line {
+    background: #ff5722!important;
+}
+
+.ups.light {
+    background: transparent!important;
+}
+
+paper-button.nav-item-container.sub {
+    padding:6px !important
+}
+
+.ups paper-button,
+.ad-preroll-message-link paper-button,
+paper-button.nav-item-container.sub {
+    background-color: #2E2F33!important;
+}
+
+.ups paper-button:focus,
+.ad-preroll-message-link paper-button:focus,
+paper-button.nav-item-container.sub:focus {
+    background-color: #202023!important;
+    border: 1px solid #2E2F33!important
+}
+
+.share-buttons .share-button iron-icon {
+    z-index: 0 !important;
+}
+
+.material .song-row.selected-song-row td, .material .song-row.currently-playing td {
+    background-color:#222326!important;
+}


### PR DESCRIPTION
This fixes issues with macOS Sierra regarding cookie issues and a big
issue with the MiniPlayer which caused to crashed.

This also includes fixed CSS Updates to all themes contained in Radiant Player.

The following should be now fixed:

https://github.com/radiant-player/radiant-player-mac/issues/600

https://github.com/radiant-player/radiant-player-mac/issues/608

https://github.com/radiant-player/radiant-player-mac/issues/574

https://github.com/radiant-player/radiant-player-mac/issues/606

https://github.com/radiant-player/radiant-player-mac/issues/605

I also done a feature request from:

https://github.com/radiant-player/radiant-player-mac/issues/607

But it is not included with this PR. I can add it to the PR if it's something needed or a decision among the Radiant Player Team.

The following PR has been tested on macOS Sierra GM, Yosemite, El Capitan, and Mavericks!

Yay for happy coding!
