### PR TITLE
Adds a feature request for pausing currently playing music on screen lock

### DIFF
--- a/radiant-player-mac/AppDelegate.m
+++ b/radiant-player-mac/AppDelegate.m
@@ -70,6 +70,27 @@
         [self playPause:self];
 }
 
+#pragma mark - screen locked/unlocked events
+
+- (void)RadiantScreenLocked {
+    
+    if ([defaults boolForKey:@"toggleMusicOnScreenLock"])
+    {
+        if (currentPlaybackMode == MUSIC_PLAYING) {
+            [self playPause:self];
+        }
+    }
+}
+
+- (void)RadiantScreenUnlocked {
+    if ([defaults boolForKey:@"toggleMusicOnScreenLock"])
+    {
+        if (currentPlaybackMode == MUSIC_PAUSED) {
+            [self playPause:self];
+        }
+    }
+}
+
 /**
  * Application finished launching, we will register the event tap callback.
  */
@@ -254,6 +275,26 @@
 
     // Register for machine sleep notifications
     [[[NSWorkspace sharedWorkspace] notificationCenter] addObserver:self selector:@selector(receiveSleepNotification:) name:NSWorkspaceWillSleepNotification object:nil];
+    
+    // Register screen locked/unlocked events
+    [[NSDistributedNotificationCenter defaultCenter] addObserver:self
+                                                        selector:@selector(RadiantScreenLocked)
+                                                            name:@"com.apple.screenIsLocked"
+                                                          object:nil];
+    
+    [[NSDistributedNotificationCenter defaultCenter] addObserver:self
+                                                        selector:@selector(RadiantScreenUnlocked)
+                                                            name:@"com.apple.screenIsUnlocked"
+                                                          object:nil];
+    
+    [[NSDistributedNotificationCenter defaultCenter] addObserver: self
+                                                        selector: @selector(RadiantScreenLocked)
+                                                            name: @"com.apple.sessionDidMoveOffConsole"
+                                                          object: nil];
+    [[NSDistributedNotificationCenter defaultCenter] addObserver: self
+                                                        selector: @selector(RadiantScreenUnlocked)
+                                                            name: @"com.apple.sessionDidMoveOnConsole"
+                                                          object: nil];
 }
 
 - (NSMutableDictionary *)styles

--- a/radiant-player-mac/Preferences.plist
+++ b/radiant-player-mac/Preferences.plist
@@ -56,5 +56,7 @@
 	<false/>
 	<key>WebKitDeveloperExtras</key>
 	<true/>
+	<key>toggleMusicOnScreenLock</key>
+	<false/>
 </dict>
 </plist>

--- a/radiant-player-mac/Preferences/PreferencesWindowController.xib
+++ b/radiant-player-mac/Preferences/PreferencesWindowController.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="9060" systemVersion="15B42" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="9532" systemVersion="14F1912" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="9060"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="9532"/>
     </dependencies>
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="PreferencesWindowController">
@@ -17,13 +17,12 @@
         </customObject>
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customView id="vbX-VO-Vnk" userLabel="General Preferences">
-            <rect key="frame" x="0.0" y="0.0" width="478" height="404"/>
+            <rect key="frame" x="0.0" y="0.0" width="478" height="464"/>
             <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
             <subviews>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="kP2-c6-sUP">
-                    <rect key="frame" x="18" y="367" width="105" height="17"/>
+                    <rect key="frame" x="18" y="427" width="105" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <animations/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Notifications:" id="BLl-CP-SxA">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -31,9 +30,8 @@
                     </textFieldCell>
                 </textField>
                 <button id="Dew-bn-PGn">
-                    <rect key="frame" x="127" y="365" width="333" height="18"/>
+                    <rect key="frame" x="127" y="425" width="333" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <animations/>
                     <buttonCell key="cell" type="check" title="Display notification when song changes" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="Qb9-rA-qYZ">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -43,9 +41,8 @@
                     </connections>
                 </button>
                 <button id="BA4-pG-D4J">
-                    <rect key="frame" x="127" y="338" width="333" height="18"/>
+                    <rect key="frame" x="127" y="398" width="333" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <animations/>
                     <buttonCell key="cell" type="check" title="Use Growl for notifications" bezelStyle="regularSquare" imagePosition="left" inset="2" id="JTn-91-56Z">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -56,9 +53,8 @@
                     </connections>
                 </button>
                 <button id="XVx-UD-G6n">
-                    <rect key="frame" x="127" y="311" width="333" height="18"/>
+                    <rect key="frame" x="127" y="371" width="333" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <animations/>
                     <buttonCell key="cell" type="check" title="Include album art in notification" bezelStyle="regularSquare" imagePosition="left" inset="2" id="Y8s-G0-q23">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -77,9 +73,8 @@
                     </connections>
                 </button>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="wI0-wb-A0h">
-                    <rect key="frame" x="18" y="229" width="105" height="17"/>
+                    <rect key="frame" x="18" y="289" width="105" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <animations/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Mini Player:" id="OVp-Sx-lNi">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -87,9 +82,8 @@
                     </textFieldCell>
                 </textField>
                 <button id="QzZ-lJ-ZC6">
-                    <rect key="frame" x="127" y="228" width="333" height="18"/>
+                    <rect key="frame" x="127" y="288" width="333" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <animations/>
                     <buttonCell key="cell" type="check" title="Show mini player in menu bar" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="KVZ-cW-hgC">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -99,9 +93,8 @@
                     </connections>
                 </button>
                 <button id="8q9-1Z-gSc">
-                    <rect key="frame" x="127" y="175" width="333" height="18"/>
+                    <rect key="frame" x="127" y="235" width="333" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <animations/>
                     <buttonCell key="cell" type="check" title="Show playing status in mini player icon" bezelStyle="regularSquare" imagePosition="left" inset="2" id="yf5-1F-e4y">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -112,9 +105,8 @@
                     </connections>
                 </button>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" setsMaxLayoutWidthAtFirstLayout="YES" id="Ewn-Vn-Jf4">
-                    <rect key="frame" x="146" y="199" width="314" height="29"/>
+                    <rect key="frame" x="146" y="259" width="314" height="29"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <animations/>
                     <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" title="Changing this preference will require a restart of the application to take effect" id="7lz-27-vG3">
                         <font key="font" metaFont="smallSystem"/>
                         <color key="textColor" name="disabledControlTextColor" catalog="System" colorSpace="catalog"/>
@@ -122,9 +114,8 @@
                     </textFieldCell>
                 </textField>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" setsMaxLayoutWidthAtFirstLayout="YES" id="iW3-JM-t6v">
-                    <rect key="frame" x="146" y="257" width="314" height="14"/>
+                    <rect key="frame" x="146" y="317" width="314" height="14"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <animations/>
                     <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" title="Requires Mac OS X 10.9 or higher" id="oHg-L4-hVc">
                         <font key="font" metaFont="smallSystem"/>
                         <color key="textColor" name="disabledControlTextColor" catalog="System" colorSpace="catalog"/>
@@ -132,9 +123,8 @@
                     </textFieldCell>
                 </textField>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" setsMaxLayoutWidthAtFirstLayout="YES" id="mPF-4G-rPI">
-                    <rect key="frame" x="146" y="296" width="314" height="14"/>
+                    <rect key="frame" x="146" y="356" width="314" height="14"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <animations/>
                     <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" title="Requires Mac OS X 10.9 or higher" id="qDC-cN-hCA">
                         <font key="font" metaFont="smallSystem"/>
                         <color key="textColor" name="disabledControlTextColor" catalog="System" colorSpace="catalog"/>
@@ -142,9 +132,8 @@
                     </textFieldCell>
                 </textField>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" setsMaxLayoutWidthAtFirstLayout="YES" id="V71-OH-XBr">
-                    <rect key="frame" x="146" y="119" width="314" height="28"/>
+                    <rect key="frame" x="146" y="179" width="314" height="28"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <animations/>
                     <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" title="Access the main menu by right-clicking the menu icon" allowsEditingTextAttributes="YES" id="pkS-R3-Khr">
                         <font key="font" metaFont="smallSystem"/>
                         <color key="textColor" name="alternateSelectedControlColor" catalog="System" colorSpace="catalog"/>
@@ -152,9 +141,8 @@
                     </textFieldCell>
                 </textField>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" setsMaxLayoutWidthAtFirstLayout="YES" id="asB-JM-HUB">
-                    <rect key="frame" x="146" y="105" width="314" height="28"/>
+                    <rect key="frame" x="146" y="165" width="314" height="28"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <animations/>
                     <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" title="Changing this preference will require a restart of the application to take effect" allowsEditingTextAttributes="YES" id="M1a-9Q-pog">
                         <font key="font" metaFont="smallSystem"/>
                         <color key="textColor" name="disabledControlTextColor" catalog="System" colorSpace="catalog"/>
@@ -162,9 +150,8 @@
                     </textFieldCell>
                 </textField>
                 <button id="q91-pT-YTA">
-                    <rect key="frame" x="127" y="272" width="333" height="18"/>
+                    <rect key="frame" x="127" y="332" width="333" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <animations/>
                     <buttonCell key="cell" type="check" title="Use iTunes style notifications" bezelStyle="regularSquare" imagePosition="left" inset="2" id="nox-ZI-U8i">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -183,9 +170,8 @@
                     </connections>
                 </button>
                 <button id="JnW-st-Alq">
-                    <rect key="frame" x="127" y="148" width="333" height="18"/>
+                    <rect key="frame" x="127" y="208" width="333" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <animations/>
                     <buttonCell key="cell" type="check" title="Hide the dock icon when the mini player is active" bezelStyle="regularSquare" imagePosition="left" inset="2" id="x2Z-xf-GDv">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -196,9 +182,8 @@
                     </connections>
                 </button>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="05f-eJ-9L9">
-                    <rect key="frame" x="18" y="81" width="105" height="17"/>
+                    <rect key="frame" x="18" y="141" width="105" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <animations/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Dock Icon:" id="hCU-za-rf6">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -206,9 +191,8 @@
                     </textFieldCell>
                 </textField>
                 <button id="tQa-56-6R0">
-                    <rect key="frame" x="127" y="79" width="333" height="18"/>
+                    <rect key="frame" x="127" y="139" width="333" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <animations/>
                     <buttonCell key="cell" type="check" title="Show album art in dock" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="sGR-H1-OiO">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -219,9 +203,8 @@
                     </connections>
                 </button>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="DRs-aQ-9fg">
-                    <rect key="frame" x="19" y="52" width="103" height="17"/>
+                    <rect key="frame" x="19" y="112" width="103" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <animations/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Updates:" id="IYs-8o-aDY">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -229,9 +212,8 @@
                     </textFieldCell>
                 </textField>
                 <button id="0sK-A0-tA8">
-                    <rect key="frame" x="127" y="51" width="333" height="18"/>
+                    <rect key="frame" x="127" y="111" width="333" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <animations/>
                     <buttonCell key="cell" type="check" title="Automatically check for updates" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="ZzK-wa-l8x">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -241,9 +223,8 @@
                     </connections>
                 </button>
                 <button id="wD5-YM-9ef">
-                    <rect key="frame" x="127" y="26" width="333" height="18"/>
+                    <rect key="frame" x="127" y="86" width="333" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <animations/>
                     <buttonCell key="cell" type="check" title="Automatically download updates" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="Qje-KO-S7L">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -256,8 +237,37 @@
                         <binding destination="Qr1-oe-yDR" name="value" keyPath="automaticallyDownloadsUpdates" id="9Ul-Aq-ZHq"/>
                     </connections>
                 </button>
+                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" setsMaxLayoutWidthAtFirstLayout="YES" id="g2c-F2-be6">
+                    <rect key="frame" x="146" y="17" width="314" height="39"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                    <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" allowsEditingTextAttributes="YES" id="tAg-Di-ow3">
+                        <font key="font" metaFont="smallSystem"/>
+                        <string key="title">Applying this will allow you to toggle the current music playing to be paused on a locked screen and plays back on a unlocked screen</string>
+                        <color key="textColor" name="disabledControlTextColor" catalog="System" colorSpace="catalog"/>
+                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                    </textFieldCell>
+                </textField>
+                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="YkB-Yc-q7U">
+                    <rect key="frame" x="26" y="59" width="97" height="17"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Screen Events:" id="a2H-We-x6w">
+                        <font key="font" metaFont="system"/>
+                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                    </textFieldCell>
+                </textField>
+                <button id="EZj-Te-czS">
+                    <rect key="frame" x="127" y="57" width="333" height="18"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                    <buttonCell key="cell" type="check" title="Toggle current music play status" bezelStyle="regularSquare" imagePosition="left" inset="2" id="5ot-3n-SRt">
+                        <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                        <font key="font" metaFont="system"/>
+                    </buttonCell>
+                    <connections>
+                        <binding destination="qKJ-ks-0kW" name="value" keyPath="values.toggleMusicOnScreenLock" id="Lzf-QH-S0b"/>
+                    </connections>
+                </button>
             </subviews>
-            <animations/>
             <point key="canvasLocation" x="260" y="280"/>
         </customView>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
@@ -268,7 +278,6 @@
                 <button id="hgY-IX-Stx">
                     <rect key="frame" x="140" y="48" width="333" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <animations/>
                     <buttonCell key="cell" type="check" title="Use custom application appearance" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="8Ld-sp-HDA">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -280,7 +289,6 @@
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" setsMaxLayoutWidthAtFirstLayout="YES" id="VL8-gZ-dPu">
                     <rect key="frame" x="53" y="146" width="326" height="28"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <animations/>
                     <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" alignment="center" title="Changing these preferences will require a restart of the application to take effect" id="z4T-NV-tMN">
                         <font key="font" metaFont="smallSystem"/>
                         <color key="textColor" name="disabledControlTextColor" catalog="System" colorSpace="catalog"/>
@@ -290,7 +298,6 @@
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="yZz-74-VDm">
                     <rect key="frame" x="33" y="22" width="103" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <animations/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Style:" id="IEE-Nf-LIX">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -300,7 +307,6 @@
                 <box verticalHuggingPriority="750" title="Box" boxType="separator" titlePosition="noTitle" id="zhW-EN-10a">
                     <rect key="frame" x="47" y="135" width="338" height="5"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <animations/>
                     <color key="borderColor" white="0.0" alpha="0.41999999999999998" colorSpace="calibratedWhite"/>
                     <color key="fillColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                     <font key="titleFont" metaFont="system"/>
@@ -308,7 +314,6 @@
                 <popUpButton verticalHuggingPriority="750" id="DeQ-rh-16G">
                     <rect key="frame" x="140" y="17" width="248" height="26"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <animations/>
                     <popUpButtonCell key="cell" type="push" title="Item 1" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" arrowPosition="arrowAtCenter" selectedItem="YVY-Hd-cdu" id="SuW-cx-g3z">
                         <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
                         <font key="font" metaFont="menu"/>
@@ -334,7 +339,6 @@
                 <button id="Ok3-NF-VQX">
                     <rect key="frame" x="140" y="110" width="333" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <animations/>
                     <buttonCell key="cell" type="check" title="Use custom title bar" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="I4Z-Ky-gCL">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -346,7 +350,6 @@
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="SCo-65-NqE">
                     <rect key="frame" x="53" y="112" width="83" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <animations/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Appearance:" id="q47-FP-1Ro">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -356,7 +359,6 @@
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" setsMaxLayoutWidthAtFirstLayout="YES" id="MZP-Mn-yFA">
                     <rect key="frame" x="140" y="78" width="314" height="29"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <animations/>
                     <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" id="1ra-uA-vMS">
                         <font key="font" metaFont="smallSystem"/>
                         <string key="title">Disable this if you're experiencing any issues 
@@ -366,7 +368,6 @@ with moving the window or the player freezing</string>
                     </textFieldCell>
                 </textField>
             </subviews>
-            <animations/>
             <point key="canvasLocation" x="292.5" y="-7"/>
         </customView>
         <customObject id="Qr1-oe-yDR" customClass="SUUpdater"/>
@@ -417,7 +418,6 @@ with moving the window or the player freezing</string>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="rDq-Nn-Fr7">
                     <rect key="frame" x="18" y="136" width="104" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <animations/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Back/Forward:" id="mg0-Oo-WdO">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -427,7 +427,6 @@ with moving the window or the player freezing</string>
                 <button id="EDO-24-zbN">
                     <rect key="frame" x="126" y="105" width="334" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <animations/>
                     <buttonCell key="cell" type="check" title="Add back and forward buttons to application bar" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="MWt-RZ-95e">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -439,7 +438,6 @@ with moving the window or the player freezing</string>
                 <button id="RM0-yC-8Bq">
                     <rect key="frame" x="126" y="134" width="334" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <animations/>
                     <buttonCell key="cell" type="check" title="Enable swipe gestures to go back and forward" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="wNl-8H-oix">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -451,7 +449,6 @@ with moving the window or the player freezing</string>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" setsMaxLayoutWidthAtFirstLayout="YES" id="z68-o1-jqs">
                     <rect key="frame" x="144" y="74" width="316" height="29"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <animations/>
                     <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" title="Changing this preference will require a restart of the application to take effect" id="Qso-vW-SGy">
                         <font key="font" metaFont="smallSystem"/>
                         <color key="textColor" name="disabledControlTextColor" catalog="System" colorSpace="catalog"/>
@@ -461,7 +458,6 @@ with moving the window or the player freezing</string>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" setsMaxLayoutWidthAtFirstLayout="YES" id="r7b-Tp-vVw">
                     <rect key="frame" x="144" y="20" width="316" height="29"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <animations/>
                     <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" title="Changing this preference will require a restart of the application to take effect" id="VMS-2j-c8q">
                         <font key="font" metaFont="smallSystem"/>
                         <color key="textColor" name="disabledControlTextColor" catalog="System" colorSpace="catalog"/>
@@ -471,7 +467,6 @@ with moving the window or the player freezing</string>
                 <button id="6NL-Uj-KNJ">
                     <rect key="frame" x="126" y="50" width="334" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <animations/>
                     <buttonCell key="cell" type="check" title="Don't replace the Apps, Notification, Share links" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="Q56-4r-0gE">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -481,7 +476,6 @@ with moving the window or the player freezing</string>
                     </connections>
                 </button>
             </subviews>
-            <animations/>
             <point key="canvasLocation" x="260" y="632.5"/>
         </customView>
         <customView id="uPE-UJ-Mvs" userLabel="Last.fm Preferences">
@@ -491,13 +485,11 @@ with moving the window or the player freezing</string>
                 <imageView horizontalHuggingPriority="251" verticalHuggingPriority="251" id="qq0-Xb-LVO">
                     <rect key="frame" x="151" y="16" width="91" height="29"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <animations/>
                     <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="proportionallyDown" image="lastfm" id="UIE-Fx-6GJ"/>
                 </imageView>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="P9p-EX-96C">
                     <rect key="frame" x="18" y="323" width="90" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <animations/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Scrobbling:" id="mHZ-3d-Tcw">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -507,7 +499,6 @@ with moving the window or the player freezing</string>
                 <button id="zMA-KR-d9H">
                     <rect key="frame" x="112" y="322" width="262" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <animations/>
                     <buttonCell key="cell" type="check" title="Scrobble songs to Last.fm" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="GwH-Oe-saC">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -519,7 +510,6 @@ with moving the window or the player freezing</string>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="rvQ-NY-Dl6">
                     <rect key="frame" x="14" y="126" width="90" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <animations/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Username:" id="xqT-BO-fjB">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -529,7 +519,6 @@ with moving the window or the player freezing</string>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="K6O-90-mBb">
                     <rect key="frame" x="14" y="96" width="90" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <animations/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Password:" id="3g3-pA-OQf">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -539,7 +528,6 @@ with moving the window or the player freezing</string>
                 <textField verticalHuggingPriority="750" id="jsE-zR-hLS">
                     <rect key="frame" x="110" y="123" width="262" height="22"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <animations/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" placeholderString="" drawsBackground="YES" id="eqt-GX-x6K">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
@@ -557,7 +545,6 @@ with moving the window or the player freezing</string>
                 <secureTextField verticalHuggingPriority="750" id="i2g-5K-Cl4">
                     <rect key="frame" x="110" y="93" width="262" height="22"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <animations/>
                     <secureTextFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" borderStyle="bezel" placeholderString="" drawsBackground="YES" usesSingleLineMode="YES" id="kdg-ZI-3hD">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
@@ -577,7 +564,6 @@ with moving the window or the player freezing</string>
                 <button verticalHuggingPriority="750" id="Xdb-Xz-u5h">
                     <rect key="frame" x="104" y="52" width="274" height="32"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <animations/>
                     <buttonCell key="cell" type="push" title="Authorize" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="oIR-4b-3nh">
                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                         <font key="font" metaFont="system"/>
@@ -589,7 +575,6 @@ with moving the window or the player freezing</string>
                 <button id="ASF-JF-LyR">
                     <rect key="frame" x="112" y="218" width="262" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <animations/>
                     <buttonCell key="cell" type="check" title="Add Last.fm button to main window" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="NQJ-kR-35L">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -601,7 +586,6 @@ with moving the window or the player freezing</string>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" setsMaxLayoutWidthAtFirstLayout="YES" id="LfQ-P8-Zwq">
                     <rect key="frame" x="131" y="187" width="243" height="29"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <animations/>
                     <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" title="Changing this preference will require a restart of the application to take effect" id="JUV-0K-skW">
                         <font key="font" metaFont="smallSystem"/>
                         <color key="textColor" name="disabledControlTextColor" catalog="System" colorSpace="catalog"/>
@@ -611,7 +595,6 @@ with moving the window or the player freezing</string>
                 <box verticalHuggingPriority="750" title="Box" boxType="separator" titlePosition="noTitle" id="wli-GL-bJ9">
                     <rect key="frame" x="12" y="165" width="368" height="5"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <animations/>
                     <color key="borderColor" white="0.0" alpha="0.41999999999999998" colorSpace="calibratedWhite"/>
                     <color key="fillColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                     <font key="titleFont" metaFont="system"/>
@@ -619,7 +602,6 @@ with moving the window or the player freezing</string>
                 <slider verticalHuggingPriority="750" id="AH3-Ok-1RM">
                     <rect key="frame" x="204" y="294" width="121" height="20"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <animations/>
                     <sliderCell key="cell" alignment="left" minValue="50" maxValue="100" doubleValue="50" tickMarkPosition="above" sliderType="linear" id="rol-26-JR2"/>
                     <connections>
                         <action selector="percentageChanged:" target="ekN-Jf-CMK" id="wlA-Hg-NPh"/>
@@ -630,7 +612,6 @@ with moving the window or the player freezing</string>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="qpn-Mm-Shc">
                     <rect key="frame" x="115" y="295" width="94" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <animations/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Scrobble after:" id="0f2-vL-pL4">
                         <font key="font" metaFont="smallSystem"/>
                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -640,7 +621,6 @@ with moving the window or the player freezing</string>
                 <button id="WBu-EO-Sau">
                     <rect key="frame" x="112" y="249" width="262" height="33"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <animations/>
                     <buttonCell key="cell" type="check" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="3im-yn-8E8">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <string key="title">Automatically love a track on Last.fm
@@ -654,7 +634,6 @@ when the track is rated "thumbs up"</string>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="Uhz-9B-Xo4">
                     <rect key="frame" x="329" y="298" width="31" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <animations/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="50%" id="TNi-k8-dvd">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -662,7 +641,6 @@ when the track is rated "thumbs up"</string>
                     </textFieldCell>
                 </textField>
             </subviews>
-            <animations/>
             <attributedString key="userComments">
                 <fragment content="labels">
                     <attributes>
@@ -686,7 +664,6 @@ when the track is rated "thumbs up"</string>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="qWk-vH-9cR">
                     <rect key="frame" x="18" y="171" width="100" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <animations/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Cookies:" id="b75-4b-w2H">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -696,7 +673,6 @@ when the track is rated "thumbs up"</string>
                 <button id="YOn-dK-BFZ">
                     <rect key="frame" x="122" y="170" width="280" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <animations/>
                     <buttonCell key="cell" type="check" title="Use Safari's cookies" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="e3e-kC-VHb">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -708,7 +684,6 @@ when the track is rated "thumbs up"</string>
                 <button id="89y-3h-8Ff">
                     <rect key="frame" x="122" y="114" width="280" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <animations/>
                     <buttonCell key="cell" type="check" title="Don't save Radiant Player's cookies" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="2Rr-id-zPZ">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -726,7 +701,6 @@ when the track is rated "thumbs up"</string>
                 <button verticalHuggingPriority="750" id="IjT-rf-SXr">
                     <rect key="frame" x="118" y="45" width="288" height="32"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <animations/>
                     <buttonCell key="cell" type="push" title="Remove all stored cookies" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="f4y-nG-Ryi">
                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                         <font key="font" metaFont="system"/>
@@ -738,7 +712,6 @@ when the track is rated "thumbs up"</string>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" setsMaxLayoutWidthAtFirstLayout="YES" id="lMI-8d-fde">
                     <rect key="frame" x="18" y="229" width="384" height="14"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <animations/>
                     <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" alignment="center" title="Changing these preference may log you out of Google Play Music" id="Zwl-r2-vbh">
                         <font key="font" metaFont="smallSystem"/>
                         <color key="textColor" name="disabledControlTextColor" catalog="System" colorSpace="catalog"/>
@@ -748,7 +721,6 @@ when the track is rated "thumbs up"</string>
                 <box verticalHuggingPriority="750" title="Box" boxType="separator" titlePosition="noTitle" id="JjR-H1-mF0">
                     <rect key="frame" x="12" y="198" width="396" height="5"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <animations/>
                     <color key="borderColor" white="0.0" alpha="0.41999999999999998" colorSpace="calibratedWhite"/>
                     <color key="fillColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                     <font key="titleFont" metaFont="system"/>
@@ -756,7 +728,6 @@ when the track is rated "thumbs up"</string>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" setsMaxLayoutWidthAtFirstLayout="YES" id="bbw-AT-mXA">
                     <rect key="frame" x="141" y="86" width="261" height="28"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <animations/>
                     <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" title="Enabling this preference will require you to log in every time you open Radiant Player" id="Q6P-fR-pZS">
                         <font key="font" metaFont="smallSystem"/>
                         <color key="textColor" name="disabledControlTextColor" catalog="System" colorSpace="catalog"/>
@@ -766,7 +737,6 @@ when the track is rated "thumbs up"</string>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" setsMaxLayoutWidthAtFirstLayout="YES" id="LaR-gk-kZT">
                     <rect key="frame" x="141" y="140" width="261" height="28"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <animations/>
                     <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" title="Changing this preference will require a restart of the application to take effect" id="inZ-bd-JZT">
                         <font key="font" metaFont="smallSystem"/>
                         <color key="textColor" name="disabledControlTextColor" catalog="System" colorSpace="catalog"/>
@@ -776,7 +746,6 @@ when the track is rated "thumbs up"</string>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" setsMaxLayoutWidthAtFirstLayout="YES" id="BUy-lx-3Vm">
                     <rect key="frame" x="122" y="20" width="280" height="28"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <animations/>
                     <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" title="This will clear all cookies stored by Radiant Player and will force a log out" id="XAY-l9-IEt">
                         <font key="font" metaFont="smallSystem"/>
                         <color key="textColor" name="disabledControlTextColor" catalog="System" colorSpace="catalog"/>
@@ -786,7 +755,6 @@ when the track is rated "thumbs up"</string>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="V8F-zm-sdI">
                     <rect key="frame" x="18" y="209" width="384" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <animations/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="These preferences require Mac OS X 10.9 or higher" id="hz2-wh-sIU">
                         <font key="font" metaFont="smallSystemBold"/>
                         <color key="textColor" name="disabledControlTextColor" catalog="System" colorSpace="catalog"/>
@@ -794,7 +762,6 @@ when the track is rated "thumbs up"</string>
                     </textFieldCell>
                 </textField>
             </subviews>
-            <animations/>
         </customView>
         <customView id="csb-l7-N8T" userLabel="Advanced Preferences">
             <rect key="frame" x="0.0" y="0.0" width="474" height="114"/>
@@ -803,7 +770,6 @@ when the track is rated "thumbs up"</string>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="GVf-gF-iGo">
                     <rect key="frame" x="18" y="77" width="106" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <animations/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Media Keys:" id="auw-Ok-dzZ">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -813,7 +779,6 @@ when the track is rated "thumbs up"</string>
                 <button id="DH3-VL-aO6">
                     <rect key="frame" x="128" y="76" width="328" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <animations/>
                     <buttonCell key="cell" type="check" title="Use alternative method to listen for media keys" bezelStyle="regularSquare" imagePosition="left" inset="2" id="Qkb-8c-2vy">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -825,7 +790,6 @@ when the track is rated "thumbs up"</string>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" setsMaxLayoutWidthAtFirstLayout="YES" id="jcU-kB-wTU">
                     <rect key="frame" x="147" y="20" width="309" height="56"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <animations/>
                     <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" id="Y3c-yy-O4p">
                         <font key="font" metaFont="smallSystem"/>
                         <string key="title">Required for some applications to work properly, like Adobe Fireworks, but will break Quick Look.
@@ -835,7 +799,6 @@ Changing this preference will require a restart of the application to take effec
                     </textFieldCell>
                 </textField>
             </subviews>
-            <animations/>
         </customView>
     </objects>
     <resources>

--- a/radiant-player-mac/Preferences/PreferencesWindowController.xib
+++ b/radiant-player-mac/Preferences/PreferencesWindowController.xib
@@ -17,11 +17,11 @@
         </customObject>
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customView id="vbX-VO-Vnk" userLabel="General Preferences">
-            <rect key="frame" x="0.0" y="0.0" width="478" height="464"/>
+            <rect key="frame" x="0.0" y="0.0" width="478" height="458"/>
             <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
             <subviews>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="kP2-c6-sUP">
-                    <rect key="frame" x="18" y="427" width="105" height="17"/>
+                    <rect key="frame" x="18" y="421" width="105" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Notifications:" id="BLl-CP-SxA">
                         <font key="font" metaFont="system"/>
@@ -30,7 +30,7 @@
                     </textFieldCell>
                 </textField>
                 <button id="Dew-bn-PGn">
-                    <rect key="frame" x="127" y="425" width="333" height="18"/>
+                    <rect key="frame" x="127" y="419" width="333" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="check" title="Display notification when song changes" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="Qb9-rA-qYZ">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -41,7 +41,7 @@
                     </connections>
                 </button>
                 <button id="BA4-pG-D4J">
-                    <rect key="frame" x="127" y="398" width="333" height="18"/>
+                    <rect key="frame" x="127" y="392" width="333" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="check" title="Use Growl for notifications" bezelStyle="regularSquare" imagePosition="left" inset="2" id="JTn-91-56Z">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -53,7 +53,7 @@
                     </connections>
                 </button>
                 <button id="XVx-UD-G6n">
-                    <rect key="frame" x="127" y="371" width="333" height="18"/>
+                    <rect key="frame" x="127" y="365" width="333" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="check" title="Include album art in notification" bezelStyle="regularSquare" imagePosition="left" inset="2" id="Y8s-G0-q23">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -73,7 +73,7 @@
                     </connections>
                 </button>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="wI0-wb-A0h">
-                    <rect key="frame" x="18" y="289" width="105" height="17"/>
+                    <rect key="frame" x="18" y="283" width="105" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Mini Player:" id="OVp-Sx-lNi">
                         <font key="font" metaFont="system"/>
@@ -82,7 +82,7 @@
                     </textFieldCell>
                 </textField>
                 <button id="QzZ-lJ-ZC6">
-                    <rect key="frame" x="127" y="288" width="333" height="18"/>
+                    <rect key="frame" x="127" y="282" width="333" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="check" title="Show mini player in menu bar" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="KVZ-cW-hgC">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -93,7 +93,7 @@
                     </connections>
                 </button>
                 <button id="8q9-1Z-gSc">
-                    <rect key="frame" x="127" y="235" width="333" height="18"/>
+                    <rect key="frame" x="127" y="229" width="333" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="check" title="Show playing status in mini player icon" bezelStyle="regularSquare" imagePosition="left" inset="2" id="yf5-1F-e4y">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -105,7 +105,7 @@
                     </connections>
                 </button>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" setsMaxLayoutWidthAtFirstLayout="YES" id="Ewn-Vn-Jf4">
-                    <rect key="frame" x="146" y="259" width="314" height="29"/>
+                    <rect key="frame" x="146" y="253" width="314" height="29"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" title="Changing this preference will require a restart of the application to take effect" id="7lz-27-vG3">
                         <font key="font" metaFont="smallSystem"/>
@@ -114,7 +114,7 @@
                     </textFieldCell>
                 </textField>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" setsMaxLayoutWidthAtFirstLayout="YES" id="iW3-JM-t6v">
-                    <rect key="frame" x="146" y="317" width="314" height="14"/>
+                    <rect key="frame" x="146" y="311" width="314" height="14"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" title="Requires Mac OS X 10.9 or higher" id="oHg-L4-hVc">
                         <font key="font" metaFont="smallSystem"/>
@@ -123,7 +123,7 @@
                     </textFieldCell>
                 </textField>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" setsMaxLayoutWidthAtFirstLayout="YES" id="mPF-4G-rPI">
-                    <rect key="frame" x="146" y="356" width="314" height="14"/>
+                    <rect key="frame" x="146" y="350" width="314" height="14"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" title="Requires Mac OS X 10.9 or higher" id="qDC-cN-hCA">
                         <font key="font" metaFont="smallSystem"/>
@@ -132,7 +132,7 @@
                     </textFieldCell>
                 </textField>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" setsMaxLayoutWidthAtFirstLayout="YES" id="V71-OH-XBr">
-                    <rect key="frame" x="146" y="179" width="314" height="28"/>
+                    <rect key="frame" x="146" y="173" width="314" height="28"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" title="Access the main menu by right-clicking the menu icon" allowsEditingTextAttributes="YES" id="pkS-R3-Khr">
                         <font key="font" metaFont="smallSystem"/>
@@ -141,7 +141,7 @@
                     </textFieldCell>
                 </textField>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" setsMaxLayoutWidthAtFirstLayout="YES" id="asB-JM-HUB">
-                    <rect key="frame" x="146" y="165" width="314" height="28"/>
+                    <rect key="frame" x="146" y="159" width="314" height="28"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" title="Changing this preference will require a restart of the application to take effect" allowsEditingTextAttributes="YES" id="M1a-9Q-pog">
                         <font key="font" metaFont="smallSystem"/>
@@ -150,7 +150,7 @@
                     </textFieldCell>
                 </textField>
                 <button id="q91-pT-YTA">
-                    <rect key="frame" x="127" y="332" width="333" height="18"/>
+                    <rect key="frame" x="127" y="326" width="333" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="check" title="Use iTunes style notifications" bezelStyle="regularSquare" imagePosition="left" inset="2" id="nox-ZI-U8i">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -170,7 +170,7 @@
                     </connections>
                 </button>
                 <button id="JnW-st-Alq">
-                    <rect key="frame" x="127" y="208" width="333" height="18"/>
+                    <rect key="frame" x="127" y="202" width="333" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="check" title="Hide the dock icon when the mini player is active" bezelStyle="regularSquare" imagePosition="left" inset="2" id="x2Z-xf-GDv">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -182,7 +182,7 @@
                     </connections>
                 </button>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="05f-eJ-9L9">
-                    <rect key="frame" x="18" y="141" width="105" height="17"/>
+                    <rect key="frame" x="18" y="135" width="105" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Dock Icon:" id="hCU-za-rf6">
                         <font key="font" metaFont="system"/>
@@ -191,7 +191,7 @@
                     </textFieldCell>
                 </textField>
                 <button id="tQa-56-6R0">
-                    <rect key="frame" x="127" y="139" width="333" height="18"/>
+                    <rect key="frame" x="127" y="133" width="333" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="check" title="Show album art in dock" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="sGR-H1-OiO">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -203,7 +203,7 @@
                     </connections>
                 </button>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="DRs-aQ-9fg">
-                    <rect key="frame" x="19" y="112" width="103" height="17"/>
+                    <rect key="frame" x="19" y="106" width="103" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Updates:" id="IYs-8o-aDY">
                         <font key="font" metaFont="system"/>
@@ -212,7 +212,7 @@
                     </textFieldCell>
                 </textField>
                 <button id="0sK-A0-tA8">
-                    <rect key="frame" x="127" y="111" width="333" height="18"/>
+                    <rect key="frame" x="127" y="105" width="333" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="check" title="Automatically check for updates" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="ZzK-wa-l8x">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -223,7 +223,7 @@
                     </connections>
                 </button>
                 <button id="wD5-YM-9ef">
-                    <rect key="frame" x="127" y="86" width="333" height="18"/>
+                    <rect key="frame" x="127" y="80" width="333" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="check" title="Automatically download updates" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="Qje-KO-S7L">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -238,17 +238,16 @@
                     </connections>
                 </button>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" setsMaxLayoutWidthAtFirstLayout="YES" id="g2c-F2-be6">
-                    <rect key="frame" x="146" y="17" width="314" height="39"/>
+                    <rect key="frame" x="146" y="11" width="314" height="39"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" allowsEditingTextAttributes="YES" id="tAg-Di-ow3">
+                    <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" title="Pause playback when screen is locked and resume when screen is unlocked." allowsEditingTextAttributes="YES" id="tAg-Di-ow3">
                         <font key="font" metaFont="smallSystem"/>
-                        <string key="title">Applying this will allow you to toggle the current music playing to be paused on a locked screen and plays back on a unlocked screen</string>
                         <color key="textColor" name="disabledControlTextColor" catalog="System" colorSpace="catalog"/>
                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="YkB-Yc-q7U">
-                    <rect key="frame" x="26" y="59" width="97" height="17"/>
+                    <rect key="frame" x="26" y="53" width="97" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Screen Events:" id="a2H-We-x6w">
                         <font key="font" metaFont="system"/>
@@ -257,7 +256,7 @@
                     </textFieldCell>
                 </textField>
                 <button id="EZj-Te-czS">
-                    <rect key="frame" x="127" y="57" width="333" height="18"/>
+                    <rect key="frame" x="127" y="51" width="333" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="check" title="Toggle current music play status" bezelStyle="regularSquare" imagePosition="left" inset="2" id="5ot-3n-SRt">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -268,7 +267,7 @@
                     </connections>
                 </button>
             </subviews>
-            <point key="canvasLocation" x="260" y="280"/>
+            <point key="canvasLocation" x="260" y="281.5"/>
         </customView>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
         <customView id="D7u-3l-nVG" userLabel="Appearance Preferences">


### PR DESCRIPTION
This is a feature which can be viewed here: 

https://github.com/radiant-player/radiant-player-mac/issues/607

![image](https://cloud.githubusercontent.com/assets/2947494/18604903/5b3f8d0c-7c49-11e6-922f-ea938bccd843.png)

Go to the Preferences -> General -> Check on Toggle current music play status

You can test it in REAL time without having to reload the Radiant Player App; do control + shift + eject or press Login Window :

![image](https://cloud.githubusercontent.com/assets/2947494/18605340/e72d72ec-7c54-11e6-8f59-cc0725e33519.png)

Both will trigger the music to PAUSE and PLAY if there is any item that is playing of-course

Screen Locked  = PAUSE music

Screen Unlocked  = PLAY music

and if you uncheck  Toggle current music play status you will see it off added for users that don't want to use this option Default state is off
