### PR TITLE
Fixes issues with plugins not loading in macOS Mojave (issue #668)

### DIFF
--- a/radiant-player-mac/WebView/CustomWebView.m
+++ b/radiant-player-mac/WebView/CustomWebView.m
@@ -29,6 +29,11 @@
     [self setAutoresizesSubviews:YES];
     [self setAcceptsTouchEvents:YES];
     [self addSubview:swipeView];
+
+    // Workaround for issue #668 Crashes upon open in Mac OS Mojave
+    // https://github.com/radiant-player/radiant-player-mac/issues/668
+    // Sets UserAgent to Safari Version 12.0 (14606.1.36.1.9) running in macOS Mojave 10.14
+    [self setApplicationNameForUserAgent:@"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.0 Safari/605.1.15"];
     
     [self setResourceLoadDelegate:self];
     [self setUIDelegate:self];


### PR DESCRIPTION
Workaround for the issue #668.

After some investigation, default user agent is apparently causing Google to serve different HTML. This causes an error (visible in the UI with two "Blocked Plug-In" labels at the bottom of the player). The internal reason is because some problem with Content Security Policy. Quoting the [comment](https://github.com/radiant-player/radiant-player-mac/issues/668#issuecomment-434037301) from [kalkama](https://github.com/kalkama):

> Any updates, since updating to Mojave, I have the blocked plug-in. Further on inspecting the element, all I see is below:
> 
> `[Error] Refused to load https://play-music.gstatic.com/fe/swf/musicplayer_cp.swf because it does not appear in the object-src directive of the Content Security Policy. [Error] Failed to load resource: Not allowed to authenticate (skyjam, line 0) [Error] Failed to load resource: Not allowed to authenticate (skyjam, line 0)`

Given that Safari should use WKWebView (which after some tests fails with the same error) I've concluded that changing the User Agent to simulate Safari could help, and indeed it does.

I've used the User Agent for Safari Version 12.0 (14606.1.36.1.9) running in macOS Mojave 10.14:

> Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.0 Safari/605.1.15
