### PR TITLE
Adds a verification on whether the process is trusted for Accessibility

### DIFF
--- a/radiant-player-mac/AppDelegate.m
+++ b/radiant-player-mac/AppDelegate.m
@@ -99,6 +99,9 @@
  */
 - (void)applicationDidFinishLaunching:(NSNotification *)aNotification
 {
+
+    [self verifyAccessibility];
+
     [window setDelegate:self];
 
     // Load the user preferences.
@@ -620,6 +623,30 @@ static CGEventRef event_tap_callback(CGEventTapProxy proxy,
                 NSLog(@"Unknown key press seen %d", usageId);
         }
     }
+}
+
+#pragma mark - Accessibility
+
+- (void) verifyAccessibility
+{
+    Boolean trusted = AXIsProcessTrusted();
+    NSLog(@"Accessibility: process is trusted check: %s", (trusted ? "YES" : "NO"));
+    if (trusted) {
+        return;
+    }
+
+    NSAlert *alert = [[NSAlert alloc] init];
+    [alert setMessageText:@"Media keys"];
+    [alert setInformativeText:@"Radiant Player needs Accessibility permission to be able to listen for media keys. You will need to enable it from System Preferences.\n\nIf you\'ve updated Radiant Player and you\'re seeing this message, you will have to disable and reenable the permission in order for Radiant Player to work properly.\n\nRadiant Player will now close, and you will have to restart it after enabling the permission."];
+    [alert addButtonWithTitle:@"Close"];
+    [alert runModal];
+
+    const void *tkeys[1] = { kAXTrustedCheckOptionPrompt };
+    const void *tvalues[1] = { kCFBooleanTrue };
+    CFDictionaryRef options = CFDictionaryCreate(NULL, tkeys, tvalues, 1, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks);
+    NSLog(@"Accessibility: process is trusted check with prompt: %s", (AXIsProcessTrustedWithOptions(options) ? "YES" : "NO"));
+
+    exit(1);
 }
 
 #pragma mark - Web Browser Actions


### PR DESCRIPTION
This fixes/mitigates the issue #674: "Application will not restart after update in macOS Mojave".

There are two possible cases here:
- app is started for the first time (or permission was removed). In that case, permission for Radiant Player will be shown in the System Preferences -> Privacy -> Accessibility, but it will be unchecked. This is the most obvious case for the user.
- app has been updated. In this case, permission for Radiant Player will be shown in the System Preferences -> Privacy -> Accessibility and *it will be checked*. The user needs to *uncheck it and then check it again*. This is not obvious at all.

This fix shows an alert explaining both cases to the user, offers the user to open the System Preferences (should be shown in both cases, not only for the first case, which was the previous behavior). This makes clear that Radiant Player will close, and that the user needs to grant the permission and restart Radiant Player manually. Also, explains the steps to be taken for the second case, so it's clear for the user that even if the permission is checked, in needs to be disabled and reenabled.